### PR TITLE
Add the Knowledge Guilds tree

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+SHELL = /bin/sh
+target = public
+
+all : $(target) ;
+
+$(target) :
+	hugo --gc --i18n-warnings -d $@
+
+.PHONY : clean
+clean :
+	-rm -r $(target)
+
+.PHONY : serve
+serve :
+	hugo serve --buildDrafts --navigateToChanged --i18n-warnings --watch

--- a/archetypes/skill.md
+++ b/archetypes/skill.md
@@ -7,5 +7,7 @@ tier: 1
 osp_cost: 10
 prerequisites: []
 requirements: []
+# replacement: true
+# restricted: true
 ---
 

--- a/content/skill/create-magical-poison.md
+++ b/content/skill/create-magical-poison.md
@@ -4,7 +4,7 @@ date: 2018-12-27T17:35:38Z
 guilds: ["Alchemists"]
 tier: 5
 osp_cost: 50
-prerequisites: ["Create Poison 3", "Poison Lore"]
+prerequisites: ["create-poison-3", "Poison Lore"]
 requirements: ["Poison lore CS"]
 restricted: true
 ---

--- a/content/skill/create-magical-poison.md
+++ b/content/skill/create-magical-poison.md
@@ -6,6 +6,7 @@ tier: 5
 osp_cost: 50
 prerequisites: ["create-poison-3", "Poison Lore"]
 requirements: ["Poison lore CS"]
+replacement: true
 restricted: true
 ---
 This skill replaces the Create Poison 3 OS and allows the character to make a level 1, a level 2 and a level 3 poison at each LT Main Event plus one magical poison an Event Season with ingredients that can be obtained and used in the relevant Guild. The character must gain permission from the Guild to use their facilities. Instead of making a new poison they may distil an existing poison to improve it by one level, subject to the normal restrictions on distilling.

--- a/content/skill/create-poison-2.md
+++ b/content/skill/create-poison-2.md
@@ -4,7 +4,7 @@ date: 2018-12-26T20:33:56Z
 guilds: ["Alchemists"]
 tier: 3
 osp_cost: 30
-prerequisites: ["Create Poison 1", "Poison Lore"]
+prerequisites: ["create-poison-1", "Poison Lore"]
 requirements: ["Poison lore CS"]
 ---
 This skill replaces the Create Poison 1 OS and allows the character to make a level 1 and a level 2 poison at each LT Main Event with ingredients that can be obtained and used in the relevant Guild. The character must gain permission from the Guild to use their facilities. Instead of making a new poison they may distil an existing poison to improve it by one level, subject to the normal restrictions on distilling.

--- a/content/skill/create-poison-2.md
+++ b/content/skill/create-poison-2.md
@@ -6,5 +6,6 @@ tier: 3
 osp_cost: 30
 prerequisites: ["create-poison-1", "Poison Lore"]
 requirements: ["Poison lore CS"]
+replacement: true
 ---
 This skill replaces the Create Poison 1 OS and allows the character to make a level 1 and a level 2 poison at each LT Main Event with ingredients that can be obtained and used in the relevant Guild. The character must gain permission from the Guild to use their facilities. Instead of making a new poison they may distil an existing poison to improve it by one level, subject to the normal restrictions on distilling.

--- a/content/skill/create-poison-3.md
+++ b/content/skill/create-poison-3.md
@@ -6,5 +6,6 @@ tier: 4
 osp_cost: 40
 prerequisites: ["create-poison-2", "Poison Lore"]
 requirements: ["Poison lore CS"]
+replacement: true
 ---
 This skill replaces the Create Poison 2 OS and allows the character to make a level 1, a level 2 and a level 3 poison at each LT Main Event with ingredients that can be obtained and used in the relevant Guild. The character must gain permission from the Guild to use their facilities. Instead of making a new poison they may distil an existing poison to improve it by one level, subject to the normal restrictions on distilling.

--- a/content/skill/create-poison-3.md
+++ b/content/skill/create-poison-3.md
@@ -4,7 +4,7 @@ date: 2018-12-27T17:32:27Z
 guilds: ["Alchemists"]
 tier: 4
 osp_cost: 40
-prerequisites: ["Create Poison 2", "Poison Lore"]
+prerequisites: ["create-poison-2", "Poison Lore"]
 requirements: ["Poison lore CS"]
 ---
 This skill replaces the Create Poison 2 OS and allows the character to make a level 1, a level 2 and a level 3 poison at each LT Main Event with ingredients that can be obtained and used in the relevant Guild. The character must gain permission from the Guild to use their facilities. Instead of making a new poison they may distil an existing poison to improve it by one level, subject to the normal restrictions on distilling.

--- a/content/skill/general-knowledge.md
+++ b/content/skill/general-knowledge.md
@@ -1,7 +1,6 @@
 ---
 title: "General Knowledge (X)"
 date: 2019-02-16T11:17:14Z
-draft: true
 guilds: ["Knowledge Guilds"]
 tier: 1
 osp_cost: 10

--- a/content/skill/general-knowledge.md
+++ b/content/skill/general-knowledge.md
@@ -1,0 +1,11 @@
+---
+title: "General Knowledge (X)"
+date: 2019-02-16T11:17:14Z
+draft: true
+guilds: ["Knowledge Guilds"]
+tier: 1
+osp_cost: 10
+prerequisites: []
+requirements: []
+---
+A character with this skill may request a general knowledge information sheet from Game Control detailing IC news about the game world. This information may contain falsehoods. New information sheets will be available at the Great Erdrejan Fayre and the Gathering. Additional information may be available at Sanctioned Events at the organiser’s discretion and they will advertise this is the event literature. The General Knowledge skills available are: Guildsman, Merchant, Rumour Monger, Storyteller, Wanderer and War Scout.

--- a/content/skill/improved-research-ability.md
+++ b/content/skill/improved-research-ability.md
@@ -1,7 +1,6 @@
 ---
 title: "Improved Research Ability"
 date: 2019-02-16T11:22:59Z
-draft: true
 guilds: ["Knowledge Guilds"]
 tier: 4
 osp_cost: 40

--- a/content/skill/improved-research-ability.md
+++ b/content/skill/improved-research-ability.md
@@ -1,0 +1,11 @@
+---
+title: "Improved Research Ability"
+date: 2019-02-16T11:22:59Z
+draft: true
+guilds: ["Knowledge Guilds"]
+tier: 4
+osp_cost: 40
+prerequisites: ["newsmonger"]
+requirements: []
+---
+Allows the submission (subject to the relevant IC arrangements) of a research request during the summer research period (subject to an overall maximum limit of one research submission per character per research period). Allows the character to assist with another character’s research, as well as performing their own research (within the same research period).

--- a/content/skill/newsmonger.md
+++ b/content/skill/newsmonger.md
@@ -1,7 +1,6 @@
 ---
 title: "Newsmonger"
 date: 2019-02-16T11:19:20Z
-draft: true
 guilds: ["Knowledge Guilds"]
 tier: 2
 osp_cost: 20

--- a/content/skill/newsmonger.md
+++ b/content/skill/newsmonger.md
@@ -1,0 +1,11 @@
+---
+title: "Newsmonger"
+date: 2019-02-16T11:19:20Z
+draft: true
+guilds: ["Knowledge Guilds"]
+tier: 2
+osp_cost: 20
+prerequisites: ["general-knowledge"]
+requirements: []
+---
+This skill replaces all the General Knowledge <X> OS. A character with this skill may request all the general knowledge information sheets from Game Control. This information may contain falsehoods. New information will be available at the Great Erdrejan Fayre and the Gathering. Additional information may be available at Sanctioned Events at the organiser’s discretion and they will advertise this in the event literature.

--- a/content/skill/newsmonger.md
+++ b/content/skill/newsmonger.md
@@ -7,5 +7,6 @@ tier: 2
 osp_cost: 20
 prerequisites: ["general-knowledge"]
 requirements: []
+replacement: true
 ---
 This skill replaces all the General Knowledge <X> OS. A character with this skill may request all the general knowledge information sheets from Game Control. This information may contain falsehoods. New information will be available at the Great Erdrejan Fayre and the Gathering. Additional information may be available at Sanctioned Events at the organiser’s discretion and they will advertise this in the event literature.

--- a/layouts/guilds/taxonomy.html
+++ b/layouts/guilds/taxonomy.html
@@ -1,0 +1,65 @@
+{{ define "main" -}}
+<h1>{{ .Title }}</h1>
+
+<style>
+    .skill-table,
+    .skill-table th,
+    .skill-table td {
+        background-color: #fafafa;
+        border-collapse: collapse;
+        border: 1px solid darkgrey;
+        color: black;
+    }
+
+    .skill-table th,
+    .skill-table td {
+        line-height: 1.5;
+        padding: .3em;
+    }
+
+    .skill {
+        background-color: white;
+        border: 2px solid darkslategray;
+        color: black;
+        display: block;
+        margin: .3em;
+        padding: .2em .5em;
+        text-align: center;
+        text-decoration: none;
+    }
+
+    .skill.restricted-skill {
+        background-color: #C6D7A5;
+        color: black;
+    }
+
+    .skill.replacement-skill {
+        border-width: 1px;
+    }
+</style>
+
+<table class="skill-table">
+    <thead>
+        <tr>
+            <th>Tier</th>
+            <th>{{ .Title }}</th>
+        </tr>
+    </thead>
+    <tbody>
+        {{- $tier := 0 }}
+        {{- range .Pages.ByParam "tier" }}
+        {{- range after 1 (seq $tier .Params.tier) }}
+        {{- if $tier }}</tr>{{ end }}
+        <tr>
+            <th scope="row">{{ . }}</th>
+            {{- $tier = . }}
+            {{- end }}
+            <td>
+                <a class="skill{{ if .Params.restricted }} restricted-skill{{ end }}{{ if .Params.replacement }} replacement-skill{{ end }}"
+                    href="{{ .Permalink }}">{{ .Title }}</a>
+            </td>
+            {{- end }}
+        </tr>
+    </tbody>
+</table>
+{{- end }}

--- a/layouts/guilds/taxonomy.html
+++ b/layouts/guilds/taxonomy.html
@@ -7,7 +7,7 @@
     .skill-table td {
         background-color: #fafafa;
         border-collapse: collapse;
-        border: 1px solid darkgrey;
+        border: 1px solid #a9a9a9;
         color: black;
     }
 
@@ -19,7 +19,7 @@
 
     .skill {
         background-color: white;
-        border: 2px solid darkslategray;
+        border: 2px solid #666;
         color: black;
         display: block;
         margin: .3em;
@@ -35,6 +35,15 @@
 
     .skill.replacement-skill {
         border-width: 1px;
+    }
+
+    .theme-base-09 .content a.skill {
+        color: black;
+    }
+
+    .skill:hover {
+        text-decoration: none;
+        border-color: black;
     }
 </style>
 

--- a/layouts/skill/single.html
+++ b/layouts/skill/single.html
@@ -17,11 +17,16 @@
     {{- end }}
 
     {{- with .Params.prerequisites }}
+    {{- $skill := $.Site.GetPage "/skill" }}
     <p>
         <strong>Pre-requisite to learn:</strong>
-        {{- range $index, $e := . }}
+        {{- range $index, $item := . }}
         {{- if $index }}, {{ end }}
-        {{ . }}
+        {{- with $skill.GetPage $item }}
+        <a href="{{ .Permalink }}">{{ .Title }}</a>
+        {{- else }}
+        {{ $item }}
+        {{- end }}
         {{- end }}.
     </p>
     {{- end }}


### PR DESCRIPTION
Also adds a table to display the guild taxonomies - highlighting replacement and restricted skills.  It's only designed for a single skill at each tier at the moment.

![Skill Table](https://user-images.githubusercontent.com/243893/52900122-2686fd80-31ea-11e9-9c71-a033d7c68fa1.png)
