### PR TITLE
Fix Missing arrows

### DIFF
--- a/layouts/guilds/taxonomy.html
+++ b/layouts/guilds/taxonomy.html
@@ -166,6 +166,9 @@
         Array.from(skills).forEach(skill => {
             if (skill.dataset.prerequisite) {
                 var prerequisite = document.getElementById(skill.dataset.prerequisite);
+                if (!prerequisite) {
+                    return;
+                }
                 new LeaderLine(prerequisite, skill, { color, endSocket, path });
             }
         });

--- a/layouts/guilds/taxonomy.html
+++ b/layouts/guilds/taxonomy.html
@@ -164,13 +164,14 @@
         var endSocket = "top";
         var skills = document.getElementsByClassName("skill");
         Array.from(skills).forEach(skill => {
-            if (skill.dataset.prerequisite) {
-                var prerequisite = document.getElementById(skill.dataset.prerequisite);
-                if (!prerequisite) {
-                    return;
-                }
-                new LeaderLine(prerequisite, skill, { color, endSocket, path });
+            if (!skill.dataset.prerequisite) {
+                return;
             }
+            var prerequisite = document.getElementById(skill.dataset.prerequisite);
+            if (!prerequisite) {
+                return;
+            }
+            new LeaderLine(prerequisite, skill, { color, endSocket, path });
         });
     }(document));
 </script>

--- a/layouts/guilds/taxonomy.html
+++ b/layouts/guilds/taxonomy.html
@@ -158,7 +158,17 @@
 <script src="/leader-line.min.js"></script>
 <script type="text/javascript">
     'use strict';
-    (function (document) {
+    function onReady(callback) {
+        if (
+            document.readyState === "complete" ||
+            (document.readyState !== "loading" && !document.documentElement.doScroll)
+        ) {
+            callback();
+        } else {
+            document.addEventListener("DOMContentLoaded", callback);
+        }
+    }
+    onReady(function () {
         var color = "black";
         var path = "fluid";
         var endSocket = "top";
@@ -173,6 +183,6 @@
             }
             new LeaderLine(prerequisite, skill, { color, endSocket, path });
         });
-    }(document));
+    });
 </script>
 {{- end }}


### PR DESCRIPTION
This happens when there's a prerequisite that's not on the table, as it blocks all further arrows.  Now just check that the prerequisite exists before trying to draw an arrow from it.