### PR TITLE
Use multiple columns to make skill forks clear

### DIFF
--- a/content/skill/cast-mass-charms.md
+++ b/content/skill/cast-mass-charms.md
@@ -6,7 +6,7 @@ osp_cost: 40
 prerequisites: ["immune-to-charms"]
 requirements: []
 replacement: true
-ladder: "detect-and-remove-beguile"
+ladder: "detect-and-remove-beguile-2"
 ---
 This skill replaces the [Immune to Charms OS][immune-to-charms]. The character is immune to all charm effects. Charms are a sub group of Mind effects and include Befriend, Beguile, Distract and Enthral.
 The character may also change the effects Befriend, Enthral or Distract into mass effects, if they are capable of casting them. This requires them to tear a total of 4 spell cards to cast as a level 3 spell effect. The enhanced spell counts in all ways as a mass spell and therefore cannot be countered. The vocals for the spell are “By the *High* power of True Song *I mass Befriend/Enthral/Distract you all*.”. Note: this effect may not be combined with Spell Reduction, or be used with the [Scribe Scroll OS][scribe-scroll].

--- a/content/skill/immune-to-charms.md
+++ b/content/skill/immune-to-charms.md
@@ -5,6 +5,6 @@ tier: 3
 osp_cost: 30
 prerequisites: ["detect-and-remove-beguile"]
 requirements: []
-ladder: "detect-and-remove-beguile"
+ladder: "detect-and-remove-beguile-2"
 ---
 This skill makes the character immune to all charm effects. Charms are a sub group of Mind effects and include Befriend, Beguile, Distract and Enthral.

--- a/content/skill/immune-to-mute.md
+++ b/content/skill/immune-to-mute.md
@@ -5,6 +5,6 @@ tier: 2
 osp_cost: 20
 prerequisites: ["immune-to-fear"]
 requirements: []
-ladder: "immune-to-fear"
+ladder: "immune-to-fear-2"
 ---
 The character is immune to the Mute effect.

--- a/content/skill/mind-healing.md
+++ b/content/skill/mind-healing.md
@@ -5,6 +5,6 @@ tier: 4
 osp_cost: 40
 prerequisites: ["advanced-healing"]
 requirements: ["Healing CS"]
-ladder: "revive"
+ladder: "revive-2"
 ---
 This skill gives a character the ability to detect and remove all Mind effects. To detect if an individual is under the influence of any Mind effect, the character must engage them in sensible conversation for at least 30 seconds, after which they may make the call “discern mind effect”. To remove a discerned Mind effect, the character must continue the conversation for at least a further minute. At the end of this period the Mind effect is removed. Using this ability requires concentration.


### PR DESCRIPTION
Where there are multiple prerequisite skills in the same column this is unclear, as the lines mask each other.  I've tried to pull them out to make it more obvious.

|Before|After|
|------|-----|
|![one-column](https://user-images.githubusercontent.com/243893/56848284-f55c3500-68de-11e9-8733-a72bfab4ad23.png)|![two-columns](https://user-images.githubusercontent.com/243893/56848268-c5149680-68de-11e9-8e44-7a9a5a992c17.png)|