### PR TITLE
Organise outlying skills

### DIFF
--- a/content/skill/cast-additional-magecraft.md
+++ b/content/skill/cast-additional-magecraft.md
@@ -6,6 +6,6 @@ osp_cost: 50
 prerequisites: ["master-countermagic"]
 requirements: ["enchanting", " or ", "shadow-magic", " OS"]
 restricted: true
-ladder: "countermagic"
+ladder: "immune-to-fear"
 ---
 The character can cast spells from the standard Spellcasting list as well as their converted spell list.

--- a/content/skill/cast-high-countermagic.md
+++ b/content/skill/cast-high-countermagic.md
@@ -5,6 +5,6 @@ tier: 3
 osp_cost: 30
 prerequisites: []
 requirements: ["Spellcasting", " or ", "Incantation", " CS"]
-ladder: "countermagic"
+ladder: "immune-to-fear"
 ---
 With this skill a character may tear 4 spell cards and cast a High Countermagic spell.

--- a/content/skill/contribute-to-2nd-ritual.md
+++ b/content/skill/contribute-to-2nd-ritual.md
@@ -5,5 +5,6 @@ tier: 1
 osp_cost: 10
 prerequisites: []
 requirements: ["Contribute to Ritual CS"]
+ladder: "herb-lore"
 ---
 This skill allows the character to contribute to a second ritual each day.

--- a/content/skill/corruption.md
+++ b/content/skill/corruption.md
@@ -7,5 +7,6 @@ osp_cost: 10
 prerequisites: []
 requirements: ["Healing CS"]
 restricted: true
+ladder: "corruption"
 ---
 The character gains the ability to cast spells from the Corruption list, instead of the Healing list. Unless granted by an item, this skill cannot be voluntarily removed under normal circumstances.

--- a/content/skill/create-antidotes.md
+++ b/content/skill/create-antidotes.md
@@ -5,5 +5,6 @@ tier: 1
 osp_cost: 10
 prerequisites: ["Poison Lore", " or ", "Potion Lore CS"]
 requirements: ["Poison Lore", " or ", "Potion Lore CS"]
+ladder: "create-poison"
 ---
 This skill allows the character to make a single antidote or protection potion at each LT Main Event with ingredients that can be obtained and used in the relevant Guild. The character must gain permission from the Guild to use their facilities. Instead of making a new antidote or protection potion they may distil an existing antidote it to improve it by one level, subject to the normal restrictions on distilling.

--- a/content/skill/discern-daemonic-being.md
+++ b/content/skill/discern-daemonic-being.md
@@ -5,6 +5,7 @@ tier: 3
 osp_cost: 30
 prerequisites: []
 requirements: []
+ladder: "herb-lore"
 ---
 A character with this skill can, after 10 seconds of concentration at a range of up to 30 feet (~9 meters), make the call “discern level of Daemonic being or possession” or ask a referee or marshal to enquire from the target. If the target examined is a Daemonic being or has a Daemonic possession they should tell the discerner the dismiss level. Some Daemonic creatures may be shielded from this effect, see [Shield Dismiss Level OS][shield-dismiss-level].
 

--- a/content/skill/discern-elemental-being.md
+++ b/content/skill/discern-elemental-being.md
@@ -5,6 +5,7 @@ tier: 3
 osp_cost: 30
 prerequisites: []
 requirements: []
+ladder: "herb-lore"
 ---
 A character with this skill can, after 10 seconds of concentration at a range of up to 30 feet (~9 meters), make the call “discern level of elemental being or possession” or ask a referee or marshal to enquire from the target. If the target examined is an elemental being or has an elemental possession they should tell the discerner the dismiss level. Some elemental creatures may be shielded from this effect, see [Shield Dismiss Level OS][shield-dismiss-level].
 

--- a/content/skill/discern-unliving.md
+++ b/content/skill/discern-unliving.md
@@ -5,6 +5,7 @@ tier: 3
 osp_cost: 30
 prerequisites: []
 requirements: []
+ladder: "herb-lore"
 ---
 A character with this skill may, after 10 seconds of concentration on a single target within 30 feet (~9 meters), make the call “discern level of Unliving being or possession” or ask a referee or marshal to enquire from the target. If the target examined is an Unliving being or has an Unliving possession they should tell the discerner the dismiss level. Some Unliving creatures may be shielded from this effect, see [Shield Dismiss Level OS][shield-dismiss-level].
 

--- a/content/skill/forensic-analysis.md
+++ b/content/skill/forensic-analysis.md
@@ -5,5 +5,6 @@ tier: 3
 osp_cost: 30
 prerequisites: []
 requirements: []
+ladder: "herb-lore"
 ---
 With this skill, the character may examine a dead body and detect if they were under the influence of a poison or potion when they died. If a referee or marshal is present they may also receive other information about what killed the character and for how long they have been dead. Any other information is purely at the discretion of the referee or marshal present.

--- a/content/skill/guarded-channelling.md
+++ b/content/skill/guarded-channelling.md
@@ -6,5 +6,6 @@ osp_cost: 50
 prerequisites: ["immune-to-disease"]
 requirements: ["Healing CS"]
 restricted: true
+ladder: "immune-to-fear"
 ---
 A Channeller with this skill may add to any non-instant Cure (in the Cure Category) spell the vocal “I claim an aura of defence”. They will then be under an Aura of Defence while casting the non-instant Cure spell. The Aura of Defence effect will end as soon as the location(s) being cured are fully cured.

--- a/content/skill/herb-lore.md
+++ b/content/skill/herb-lore.md
@@ -5,5 +5,6 @@ tier: 1
 osp_cost: 10
 prerequisites: []
 requirements: []
+ladder: "herb-lore"
 ---
 This skill allows the character to use healing herbs. Characters with this skill can collect up to 5 ‘Herb Lore’ cards per event, dependant on the local environment, from the relevant Guild at LT Main Events. These cards will have the type of damage they can cure written on them. Herbs will duplicate the effects of Cure Wound, Remove Disease or Purge Poison. They take 10 seconds to use and this does not require concentration. At Sanctioned Events cards may be given by the event organisers or characters may be able to collect them IC. The cards represent herbs IC and can be stolen or traded.

--- a/content/skill/immune-to-disease.md
+++ b/content/skill/immune-to-disease.md
@@ -5,5 +5,6 @@ tier: 3
 osp_cost: 30
 prerequisites: []
 requirements: ["Healing CS"]
+ladder: "immune-to-fear"
 ---
 This skill makes the character immune to the Disease effect.

--- a/content/skill/immune-to-lethal-alchemical-poisons.md
+++ b/content/skill/immune-to-lethal-alchemical-poisons.md
@@ -5,5 +5,6 @@ tier: 4
 osp_cost: 40
 prerequisites: []
 requirements: []
+ladder: "herb-lore"
 ---
 The character is immune to all Lethal Alchemical Poisons.

--- a/content/skill/master-countermagic.md
+++ b/content/skill/master-countermagic.md
@@ -6,7 +6,7 @@ osp_cost: 40
 prerequisites: ["cast-high-countermagic", " or ", "high-magic-x", " (Spellcasting)"]
 requirements: ["Spellcasting", " or ", "Incantation CS"]
 replacement: true
-ladder: "countermagic"
+ladder: "immune-to-fear"
 ---
 This skill replaces the [Cast High Countermagic OS][cast-high-countermagic]. They may cast the High Countermagic spell and have Spell Reduction (1) for the effects Iron Will and High Countermagic.
 

--- a/content/skill/mortician-expert.md
+++ b/content/skill/mortician-expert.md
@@ -7,7 +7,7 @@ prerequisites: ["mortician"]
 requirements: ["Physician CS"]
 replacement: true
 restricted: true
-ladder: "mortician"
+ladder: "corruption"
 ---
 This skill replaces the [Mortician OS][mortician] and enables a character with the Physician CS to use it on corporeal Unliving characters. A character with Mortician (Expert) is also able to repair extreme damage done to a corporeal Unliving such as scars, broken bones and lost limbs. To repair extreme damage the Mortician (Expert) must inflict a mortal wound on the damaged location using a small weapon and spend a total of 1 minute of roleplay action. After this minute a referee or marshal will inform if the extreme damage has been repaired but the location will still be suffering from the mortal wound.
 

--- a/content/skill/mortician.md
+++ b/content/skill/mortician.md
@@ -6,6 +6,6 @@ osp_cost: 20
 prerequisites: []
 requirements: ["Physician CS"]
 restricted: true
-ladder: "mortician"
+ladder: "corruption"
 ---
 Enables a character with the Physician CS to use it on corporeal Unliving characters.

--- a/content/skill/necromancy.md
+++ b/content/skill/necromancy.md
@@ -7,5 +7,6 @@ osp_cost: 10
 prerequisites: []
 requirements: ["corruption", ", ", "shadow-magic", " or ", "dark-incantation", " OS"]
 restricted: true
+ladder: "herb-lore"
 ---
 The character may cast spells from the Necromancy list to the highest level that they can cast in any of the pre-requisite spell lists. If they also have the Ritual Magic CS at any level they gain a bonus when summoning Unliving.

--- a/content/skill/perform-transport-rite.md
+++ b/content/skill/perform-transport-rite.md
@@ -5,5 +5,6 @@ tier: 1
 osp_cost: 10
 prerequisites: []
 requirements: ["Spellcasting", ", ", "Incantation", " or ", "Healing CS"]
+ladder: "immune-to-fear"
 ---
 This allows the person to perform a transport rite without having the ritual magic CS. This does not allow a character to perform any other rite.

--- a/content/skill/plus-1-lhv.md
+++ b/content/skill/plus-1-lhv.md
@@ -6,5 +6,6 @@ osp_cost: 50
 prerequisites: []
 requirements: ["Body development 2 CS", " or ", "Lammie or Loresheet"]
 restricted: true
+ladder: "sage"
 ---
 The character gains +1 LHV, subject to the rule of double.

--- a/content/skill/repair-destroyed-items.md
+++ b/content/skill/repair-destroyed-items.md
@@ -5,6 +5,6 @@ tier: 2
 osp_cost: 20
 prerequisites: ["weaponsmith-apprentice"]
 requirements: []
-ladder: "weaponsmith-plus"
+ladder: "tracking"
 ---
 This skill allows the character to repair items destroyed by the Shatter or Crush effect. This takes 30 seconds of concentration. This has no effect on armour.

--- a/content/skill/scribe-scroll.md
+++ b/content/skill/scribe-scroll.md
@@ -5,5 +5,6 @@ tier: 2
 osp_cost: 20
 prerequisites: []
 requirements: ["Spellcasting", ", ", "Incantation", " or ", "Healing CS"]
+ladder: "herb-lore"
 ---
 At each LT Main Event the character may produce two scrolls at each Moot, three at the Great Erdrejan Fayre or Gathering, for each level of casting they have in each pre requisite CS. The character must be in the relevant Guild’s area to use this skill and purchase the materials needed. The player may create their own scroll phys- rep or obtain a standard scroll phys-rep from the relevant Guild. Standards to which the scroll phys-rep must conform can be obtained from either the Guilds or Game Control but the wording on the scroll must contain the vocals of the spell effect. E.g. Spellcasting 2 and Incantation 1 allow the production of two level 1 Incantation scrolls, two level 1 Spellcasting scrolls and two level 2 Spellcasting scrolls at the Moots( if they had High Magic Spellcasting, they would also be able to produce two level 3 Spellcasting scrolls). The intrinsic cost for the materials will vary from time to time and can be obtained from the relevant Guild. Note: Effects or abilities may not be written into scrolls using this OS.

--- a/content/skill/shield-dismiss-level.md
+++ b/content/skill/shield-dismiss-level.md
@@ -6,5 +6,6 @@ osp_cost: 30
 prerequisites: []
 requirements: []
 restricted: true
+ladder: "command"
 ---
 If a Discern \<X> of the correct type is used on the character then they may respond "\<X>, discern shielded". If the discerning character spends a further 10 seconds discerning then a referee or marshal will privately obtain the dismiss level and pass it to the discerning character.

--- a/content/skill/shield-mastery.md
+++ b/content/skill/shield-mastery.md
@@ -5,5 +5,6 @@ tier: 3
 osp_cost: 30
 prerequisites: []
 requirements: ["Shield Use CS"]
+ladder: "tracking"
 ---
 A character with this skill can use a shield to parry weapon blows inflicting the Crush effect without damaging the shield or the character, unless it has the Artefact damage type. This OS will not alter any other damage effect that ignores armour.

--- a/content/skill/sleepless-chanting.md
+++ b/content/skill/sleepless-chanting.md
@@ -5,6 +5,6 @@ tier: 2
 osp_cost: 20
 prerequisites: []
 requirements: []
-ladder: "sleepless-chanting"
+ladder: "herb-lore"
 ---
 The character is immune to any sleep effect while casting a Chant effect.

--- a/content/skill/tutor.md
+++ b/content/skill/tutor.md
@@ -6,6 +6,6 @@ osp_cost: 40
 prerequisites: []
 requirements: []
 restricted: true
-ladder: "tutor"
+ladder: "command"
 ---
 This allows the character to teach another character any OS that they currently possess on their character card, except the Tutor OS. They may teach a maximum of two skills each Event Season, and each skill may be up to and including Tier 4. Restricted skills may only be taught if the pupil has fulfilled any IC pre-requisites needed to learn that skill. The character learning the skill must still possess any pre-requisites needed to learn the new skill. This Occupational Skill may not be used while under a command effect. To Track the use of this skill, an administrative skill may be placed upon the Tutoring Characters Account.

--- a/content/skill/unending-voice.md
+++ b/content/skill/unending-voice.md
@@ -6,7 +6,7 @@ osp_cost: 30
 prerequisites: ["sleepless-chanting"]
 requirements: []
 replacement: true
-ladder: "sleepless-chanting"
+ladder: "herb-lore"
 ---
 This skill replaces the [Sleepless Chanting OS][sleepless-chanting] and grants the character Spell Reduction (1) for all Chant effects. In addition the character is immune to any Sleep effect while casting a Chant effect.
 

--- a/content/skill/weaponsmith-apprentice.md
+++ b/content/skill/weaponsmith-apprentice.md
@@ -5,6 +5,6 @@ tier: 1
 osp_cost: 10
 prerequisites: []
 requirements: []
-ladder: "weaponsmith"
+ladder: "t-weaponsmith"
 ---
 This skill allows the character to make a level 1 melee weapon or shield at each LT Main Event with tools that can be obtained and used in the relevant Guild. The character must gain permission from the relevant Guild to use their facilities. Instead of making a new weapon/shield they may reforge an existing weapon or shield and improve it by one level, subject to the normal restrictions on reforging.

--- a/content/skill/weaponsmith-artisan.md
+++ b/content/skill/weaponsmith-artisan.md
@@ -6,7 +6,7 @@ osp_cost: 40
 prerequisites: ["weaponsmith-apprentice"]
 requirements: []
 replacement: true
-ladder: "weaponsmith"
+ladder: "t-weaponsmith"
 ---
 This skill replaces the [Weaponsmith (Apprentice) OS][weaponsmith-apprentice] and allows the character to make a level 1 and a level 2 melee weapon or shield at each LT Main Event with tools that can be obtained and used in the relevant Guild. The character must gain permission from the relevant Guild to use their facilities. Instead of making a new weapon or shield they may reforge an existing weapon or shield and improve it by one level, subject to the normal restrictions on reforging.
 

--- a/content/skill/weaponsmith-master.md
+++ b/content/skill/weaponsmith-master.md
@@ -7,7 +7,7 @@ prerequisites: ["weaponsmith-artisan"]
 requirements: []
 replacement: true
 restricted: true
-ladder: "weaponsmith"
+ladder: "t-weaponsmith"
 ---
 This skill replaces the [Weaponsmith (Artisan) OS][weaponsmith-artisan] and allows the character to make a level 1, a level 2 and a level 3 melee weapon or shield at each LT Main Event with tools that can be obtained and used in the relevant Guild. The character must gain permission from the relevant Guild to use their facilities. Instead of making a new weapon or shield they may reforge an existing weapon or shield and improve it by one level, subject to the normal restrictions on reforging.
 


### PR DESCRIPTION
This manually organises a few skills that are outlying on their guild pages, in particular:

* Cast High Countermagic
* Create Antidote
* Guarded Channelling
* Herb Lore
* Immune to Disease
* Perform Transport Rite
* Shield Mastery

A number of other skills had to be moved around to facilitate this organisation.  This also means that "ladder" is no longer a safe way of identifying related skills.