### PR TITLE
Update Hugo to v0.55.0

### DIFF
--- a/archetypes/guilds.md
+++ b/archetypes/guilds.md
@@ -1,4 +1,6 @@
 ---
 title: "{{ replace .Name "-" " " | title }}"
-menu: "guilds"
+menu:
+    guilds:
+        identifier: "{{ .Name }}"
 ---

--- a/content/guilds/_index.md
+++ b/content/guilds/_index.md
@@ -1,4 +1,6 @@
 ---
 title: "Guilds"
-menu: "main"
+menu:
+  main:
+    identifier: "guilds"
 ---

--- a/content/guilds/knowledge-guilds/_index.md
+++ b/content/guilds/knowledge-guilds/_index.md
@@ -3,5 +3,4 @@ title: "Knowledge Guilds"
 menu:
     guilds:
         identifier: "knowledge-guilds"
-
 ---

--- a/content/skill/_index.md
+++ b/content/skill/_index.md
@@ -1,4 +1,6 @@
 ---
 title: "Skills"
-menu: "main"
+menu:
+    main:
+        identifier: "skills"
 ---

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@
   command = "hugo -b $URL/"
 
 [build.environment]
-  HUGO_VERSION = "0.53"
+  HUGO_VERSION = "0.55.0"
 
 [context.deploy-preview]
   command = "hugo --i18n-warnings -b $DEPLOY_PRIME_URL/"

--- a/themes/fuse-search/layouts/_default/search.json
+++ b/themes/fuse-search/layouts/_default/search.json
@@ -1,6 +1,6 @@
 {{- $index := slice -}}
 {{- range where .Site.RegularPages ".Params.searchable" "!=" false -}}
-    {{- $page := dict "id" .UniqueID "title" .Title "contents" (.Plain | chomp) "summary" (.Summary | chomp) "permalink" .Permalink "guilds" .Params.guilds }}
+    {{- $page := dict "id" .File.UniqueID "title" .Title "contents" (.Plain | chomp) "summary" (.Summary | chomp) "permalink" .Permalink "guilds" .Params.guilds }}
     {{- $index = $index | append $page -}}
 {{- end -}}
 {{- jsonify $index -}}

--- a/themes/fuse-search/layouts/_default/search.json
+++ b/themes/fuse-search/layouts/_default/search.json
@@ -1,5 +1,5 @@
 {{- $index := slice -}}
-{{- range where .Site.RegularPages ".Params.searchable" "!=" false -}}
+{{- range where site.RegularPages ".Params.searchable" "!=" false -}}
     {{- $page := dict "id" .File.UniqueID "title" .Title "contents" (.Plain | chomp) "summary" (.Summary | chomp) "permalink" .Permalink "guilds" .Params.guilds }}
     {{- $index = $index | append $page -}}
 {{- end -}}

--- a/themes/lt-osp/layouts/404.html
+++ b/themes/lt-osp/layouts/404.html
@@ -1,5 +1,5 @@
 {{ define "main" -}}
 <h1>404: Page not found</h1>
-<p class="lead">Sorry, we've misplaced that URL or it's pointing to something that doesn't exist. <a
-        href="{{ .Site.BaseURL }}">Head back home</a> to try finding it again.</p>
+<p class="lead">Sorry, we've misplaced that URL or it's pointing to something that doesn't exist.
+        <a href="{{ site.BaseURL }}">Head back home</a> to try finding it again.</p>
 {{- end }}

--- a/themes/lt-osp/layouts/_default/baseof.html
+++ b/themes/lt-osp/layouts/_default/baseof.html
@@ -17,7 +17,7 @@
     {{ range .AlternativeOutputFormats -}}
     {{ printf "<link rel=%q type=%q href=%q title=%q>" .Rel .MediaType.Type .RelPermalink $.Site.Title | safeHTML }}
     {{ end -}}
-    {{ .Hugo.Generator }}
+    {{ hugo.Generator }}
 </head>
 
 <body>

--- a/themes/lt-osp/layouts/_default/baseof.html
+++ b/themes/lt-osp/layouts/_default/baseof.html
@@ -1,21 +1,21 @@
 <!DOCTYPE html>
-<html lang="{{ .Site.LanguageCode }}">
+<html lang="{{ site.LanguageCode }}">
 
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>
-        {{- if eq .Title .Site.Title -}}
-        {{- .Site.Title -}}
+        {{- if eq .Title site.Title -}}
+        {{- site.Title -}}
         {{- else -}}
-        {{- with .Title -}}{{- . }} &bull; {{ end -}}{{- .Site.Title -}}
+        {{- with .Title -}}{{- . }} &bull; {{ end -}}{{- site.Title -}}
         {{- end -}}
     </title>
     {{ $style := resources.Get "sass/main.scss" | resources.ToCSS | resources.Minify | resources.Fingerprint -}}
     <link rel="stylesheet" href="{{ $style.Permalink }}">
     {{ block "scripts" . }}{{ end }}
     {{ range .AlternativeOutputFormats -}}
-    {{ printf "<link rel=%q type=%q href=%q title=%q>" .Rel .MediaType.Type .RelPermalink $.Site.Title | safeHTML }}
+    {{ printf "<link rel=%q type=%q href=%q title=%q>" .Rel .MediaType.Type .RelPermalink site.Title | safeHTML }}
     {{ end -}}
     {{ hugo.Generator }}
 </head>

--- a/themes/lt-osp/layouts/guilds/list.html
+++ b/themes/lt-osp/layouts/guilds/list.html
@@ -2,7 +2,7 @@
 <h1>{{ .Title }}</h1>
 {{ .Content }}
 
-{{- with .Site.Menus.guilds }}
+{{- with site.Menus.guilds }}
 <ul>
     {{- range . }}
     <li><a href="{{ .URL }}">{{ .Title }}</a>

--- a/themes/lt-osp/layouts/guilds/taxonomy-column.html
+++ b/themes/lt-osp/layouts/guilds/taxonomy-column.html
@@ -23,9 +23,9 @@
             <td>
                 {{ range . }}
                 <a class="skill{{ if .Params.restricted }} restricted-skill{{ end }}{{ if .Params.replacement }} replacement-skill{{ end }}"
-                    id="skill-{{ .UniqueID }}" href="{{ .Permalink }}"
+                    id="skill-{{ .File.UniqueID }}" href="{{ .Permalink }}"
                     {{ range .Params.prerequisites }}{{- with $skills.GetPage . }}
-                    data-prerequisite="skill-{{ .UniqueID }}" {{ end }}{{ end }}>
+                    data-prerequisite="skill-{{ .File.UniqueID }}" {{ end }}{{ end }}>
                     {{ .Title }}
                 </a>
                 {{ end }}
@@ -51,9 +51,9 @@
             <td>
                 {{ range .Pages }}
                 <a class="skill{{ if .Params.restricted }} restricted-skill{{ end }}{{ if .Params.replacement }} replacement-skill{{ end }}"
-                    id="skill-{{ .UniqueID }}" href="{{ .Permalink }}"
+                    id="skill-{{ .File.UniqueID }}" href="{{ .Permalink }}"
                     {{ range .Params.prerequisites }}{{- with $skills.GetPage . }}
-                    data-prerequisite="skill-{{ .UniqueID }}" {{ end }}{{ end }}>
+                    data-prerequisite="skill-{{ .File.UniqueID }}" {{ end }}{{ end }}>
                     {{ .Title }}
                 </a>
                 {{ end }}

--- a/themes/lt-osp/layouts/guilds/taxonomy-column.html
+++ b/themes/lt-osp/layouts/guilds/taxonomy-column.html
@@ -8,10 +8,7 @@
 
 {{ .Content }}
 
-{{- $skills := $.Site.GetPage "/skill" }}
-{{- $guilds := $.Site.GetPage "/guilds" }}
-
-{{- with $pages := where .Pages ".Params.guild" nil }}
+{{- with where .Pages ".Params.guild" nil }}
 <table class="skill-table">
     <thead>
         <tr>
@@ -21,14 +18,9 @@
     <tbody>
         <tr>
             <td>
-                {{ range . }}
-                <a class="skill{{ if .Params.restricted }} restricted-skill{{ end }}{{ if .Params.replacement }} replacement-skill{{ end }}"
-                    id="skill-{{ .File.UniqueID }}" href="{{ .Permalink }}"
-                    {{ range .Params.prerequisites }}{{- with $skills.GetPage . }}
-                    data-prerequisite="skill-{{ .File.UniqueID }}" {{ end }}{{ end }}>
-                    {{ .Title }}
-                </a>
-                {{ end }}
+                {{ range . -}}
+                {{ .Render "cell" }}
+                {{- end }}
             </td>
         </tr>
     </tbody>
@@ -41,7 +33,7 @@
     <thead>
         <tr>
             <th>
-                {{ $guilds.GetPage .Key | partial "guild-link" }}
+                {{ site.GetPage (printf "/guilds/%s" .Key) | partial "guild-link" }}
             </th>
         </tr>
     </thead>
@@ -50,12 +42,7 @@
         <tr>
             <td>
                 {{ range .Pages }}
-                <a class="skill{{ if .Params.restricted }} restricted-skill{{ end }}{{ if .Params.replacement }} replacement-skill{{ end }}"
-                    id="skill-{{ .File.UniqueID }}" href="{{ .Permalink }}"
-                    {{ range .Params.prerequisites }}{{- with $skills.GetPage . }}
-                    data-prerequisite="skill-{{ .File.UniqueID }}" {{ end }}{{ end }}>
-                    {{ .Title }}
-                </a>
+                {{ .Render "cell" }}
                 {{ end }}
             </td>
         </tr>

--- a/themes/lt-osp/layouts/guilds/taxonomy-list.html
+++ b/themes/lt-osp/layouts/guilds/taxonomy-list.html
@@ -19,9 +19,9 @@
         <div class="skill-ladder">
             {{ range .ByWeight -}}
             <a class="skill{{ if .Params.restricted }} restricted-skill{{ end }}{{ if .Params.replacement }} replacement-skill{{ end }}"
-                id="skill-{{ .UniqueID }}" href="{{ .Permalink }}"
-                {{ range .Params.prerequisites }}{{- with $skills.GetPage . }} data-prerequisite="skill-{{ .UniqueID }}"
-                {{ end }}{{ end }}>
+                id="skill-{{ .File.UniqueID }}" href="{{ .Permalink }}"
+                {{ range .Params.prerequisites }}{{- with $skills.GetPage . }}
+                data-prerequisite="skill-{{ .File.UniqueID }}" {{ end }}{{ end }}>
                 {{ .Title }}
             </a>
             {{- end }}
@@ -32,9 +32,9 @@
         {{ range .ByTitle -}}
         <div class="skill-ladder skill-ladder-misc">
             <a class="skill{{ if .Params.restricted }} restricted-skill{{ end }}{{ if .Params.replacement }} replacement-skill{{ end }}"
-                id="skill-{{ .UniqueID }}" href="{{ .Permalink }}"
-                {{ range .Params.prerequisites }}{{- with $skills.GetPage . }} data-prerequisite="skill-{{ .UniqueID }}"
-                {{ end }}{{ end }}>
+                id="skill-{{ .File.UniqueID }}" href="{{ .Permalink }}"
+                {{ range .Params.prerequisites }}{{- with $skills.GetPage . }}
+                data-prerequisite="skill-{{ .File.UniqueID }}" {{ end }}{{ end }}>
                 {{ .Title }}
             </a>
         </div>

--- a/themes/lt-osp/layouts/guilds/taxonomy-list.html
+++ b/themes/lt-osp/layouts/guilds/taxonomy-list.html
@@ -8,7 +8,6 @@
 
 {{ .Content }}
 
-{{- $skills := $.Site.GetPage "/skill" }}
 <section>
     <header class="skill-list-title">
         {{ .Title }}
@@ -18,12 +17,7 @@
         {{ range .GroupByParam "ladder" -}}
         <div class="skill-ladder">
             {{ range .ByWeight -}}
-            <a class="skill{{ if .Params.restricted }} restricted-skill{{ end }}{{ if .Params.replacement }} replacement-skill{{ end }}"
-                id="skill-{{ .File.UniqueID }}" href="{{ .Permalink }}"
-                {{ range .Params.prerequisites }}{{- with $skills.GetPage . }}
-                data-prerequisite="skill-{{ .File.UniqueID }}" {{ end }}{{ end }}>
-                {{ .Title }}
-            </a>
+            {{ .Render "cell" }}
             {{- end }}
         </div>
         {{- end }}
@@ -31,12 +25,7 @@
         {{ with where .Pages ".Params.ladder" "==" nil -}}
         {{ range .ByTitle -}}
         <div class="skill-ladder skill-ladder-misc">
-            <a class="skill{{ if .Params.restricted }} restricted-skill{{ end }}{{ if .Params.replacement }} replacement-skill{{ end }}"
-                id="skill-{{ .File.UniqueID }}" href="{{ .Permalink }}"
-                {{ range .Params.prerequisites }}{{- with $skills.GetPage . }}
-                data-prerequisite="skill-{{ .File.UniqueID }}" {{ end }}{{ end }}>
-                {{ .Title }}
-            </a>
+            {{ .Render "cell" }}
         </div>
         {{- end }}
         {{- end }}

--- a/themes/lt-osp/layouts/guilds/taxonomy.html
+++ b/themes/lt-osp/layouts/guilds/taxonomy.html
@@ -70,9 +70,9 @@
             {{- end }}
             <td>
                 <a class="skill{{ if .Params.restricted }} restricted-skill{{ end }}{{ if .Params.replacement }} replacement-skill{{ end }}"
-                    id="skill-{{ .UniqueID }}" href="{{ .Permalink }}"
+                    id="skill-{{ .File.UniqueID }}" href="{{ .Permalink }}"
                     {{ range .Params.prerequisites }}{{- with $skills.GetPage . }}
-                    data-prerequisite="skill-{{ .UniqueID }}" {{ end }}{{ end }}>
+                    data-prerequisite="skill-{{ .File.UniqueID }}" {{ end }}{{ end }}>
                     {{ .LinkTitle }}
                 </a>
             </td>

--- a/themes/lt-osp/layouts/guilds/taxonomy.html
+++ b/themes/lt-osp/layouts/guilds/taxonomy.html
@@ -16,7 +16,6 @@
         </tr>
     </thead>
     <tbody>
-        {{- $skills := $.Site.GetPage "/skill" }}
         {{- $default_ladder := "none" }}
         {{- $ladder_count := 0}}
         {{- $scratch := newScratch }}
@@ -69,12 +68,7 @@
             {{- end }}
             {{- end }}
             <td>
-                <a class="skill{{ if .Params.restricted }} restricted-skill{{ end }}{{ if .Params.replacement }} replacement-skill{{ end }}"
-                    id="skill-{{ .File.UniqueID }}" href="{{ .Permalink }}"
-                    {{ range .Params.prerequisites }}{{- with $skills.GetPage . }}
-                    data-prerequisite="skill-{{ .File.UniqueID }}" {{ end }}{{ end }}>
-                    {{ .LinkTitle }}
-                </a>
+                {{ .Render "cell" }}
             </td>
             {{- $col = add $col 1 }}
             {{- end }}

--- a/themes/lt-osp/layouts/index.html
+++ b/themes/lt-osp/layouts/index.html
@@ -1,7 +1,7 @@
 {{ define "main" -}}
 <div class="skills">
   <h1>{{ .Title }}</h1>
-  <p>{{ .Site.Params.description }}</p>
+  <p>{{ site.Params.description }}</p>
   {{ range .Data.Pages -}}
   <article class="post">
     <h2 class="post-title">

--- a/themes/lt-osp/layouts/partials/guilds/nav.html
+++ b/themes/lt-osp/layouts/partials/guilds/nav.html
@@ -13,7 +13,7 @@
 {{- end }}
 {{- $parent := .Parent }}
 {{- if $parent }}
-{{- range $.Site.Menus.guilds }}
+{{- range site.Menus.guilds }}
 {{- if eq (default .Name .Identifier) $parent }}
 <p>Back to <a href="{{ .URL }}" rel="parent">{{ .Title }}</a></p>
 {{- end }}

--- a/themes/lt-osp/layouts/partials/header.html
+++ b/themes/lt-osp/layouts/partials/header.html
@@ -1,20 +1,19 @@
 <header class="banner" role="banner">
     <div class="title-menu">
-        <h1><a href="{{ "" | relURL }}">{{ .Site.Title }}</a></h1>
+        <h1><a href="{{ "" | relURL }}">{{ site.Title }}</a></h1>
 
         {{- $hamburger := resources.Get "svg/menu.svg" -}}
         <a href="#main-menu" class="menu-toggle" aria-label="Open main menu">
             <span class="sr-only">Open main menu</span><img src="{{ $hamburger.Permalink }}" aria-hidden="true"></a>
     </div>
-    {{ with .Site.Menus.main -}}
     <nav class="main-menu" id="main-menu" aria-label="Main menu">
         <a href="#main-menu-toggle" class="menu-close" aria-label="Close main menu">
             <span class="sr-only">Open main menu</span><img src="{{ $hamburger.Permalink }}" aria-hidden="true"></a>
         <ul>
-            {{ range . -}}
+            {{- range site.Menus.main }}
             <li><a href="{{ .URL }}">{{ .Title }}</a></li>
             {{ end -}}
-            {{- with $.Site.GetPage "/search" -}}
+            {{- with site.GetPage "/search" -}}
             <li class="search">
                 <form role="search" method="GET" action="{{ .Permalink }}" class="search">
                     <label for="search-query">🔍</label>
@@ -25,7 +24,6 @@
             {{- end -}}
         </ul>
     </nav>
-    {{ end -}}
 </header>
 <section id="header-search-results">
     <p class="no-search-results" style="display: none">

--- a/themes/lt-osp/layouts/partials/skill-list.html
+++ b/themes/lt-osp/layouts/partials/skill-list.html
@@ -1,6 +1,5 @@
-{{- $skills := .skills -}}
-{{- range $item := .list -}}
-{{- with $skills.GetPage $item -}}
+{{- range $item := . -}}
+{{- with site.GetPage (printf "/skill/%s" $item) -}}
 <a href="{{ .Permalink }}">{{ .Title }}</a>
 {{- else -}}
 {{ $item }}

--- a/themes/lt-osp/layouts/skill/cell.html
+++ b/themes/lt-osp/layouts/skill/cell.html
@@ -1,0 +1,6 @@
+<a class="skill{{ if .Params.restricted }} restricted-skill{{ end }}{{ if .Params.replacement }} replacement-skill{{ end }}"
+    id="skill-{{ .File.UniqueID }}" href="{{ .Permalink }}"
+    {{ range .Params.prerequisites }}{{- with site.GetPage (printf "/skill/%s" .) }}
+    data-prerequisite="skill-{{ .File.UniqueID }}" {{ end }}{{ end }}>
+    {{ .LinkTitle }}
+</a>

--- a/themes/lt-osp/layouts/skill/single.html
+++ b/themes/lt-osp/layouts/skill/single.html
@@ -5,7 +5,7 @@
     {{- with .Params.tier }}<p><strong>Tier:</strong> {{ . }}</p>{{ end }}
 
     {{- with .Params.guilds }}
-    {{- $guilds := $.Site.GetPage "/guilds" }}
+    {{- $guilds := site.GetPage "/guilds" }}
     <p>
         <strong>Guilds:</strong>
         {{- $len := len . }}
@@ -18,19 +18,17 @@
     </p>
     {{- end }}
 
-    {{- $skills := $.Site.GetPage "/skill" }}
     {{- with .Params.prerequisites }}
     <p>
         <strong>Pre-requisite to learn:</strong>
-        {{ partial "skill-list" (dict "list" . "skills" $skills) }}
+        {{ partial "skill-list" . }}
     </p>
     {{- end }}
 
     {{- with .Params.requirements }}
-    {{- $skill := $.Site.GetPage "/skill" }}
     <p>
         <strong>Requirements to use:</strong>
-        {{ partial "skill-list" (dict "list" . "skills" $skills) }}
+        {{ partial "skill-list" . }}
     </p>
     {{- end }}
 

--- a/themes/lt-osp/theme.toml
+++ b/themes/lt-osp/theme.toml
@@ -8,7 +8,7 @@ description = ""
 homepage = "http://github.com/sparksp/lt-osp/"
 tags = []
 features = []
-min_version = "0.42"
+min_version = "0.55.0"
 
 [author]
   name = "Phill Sparks"


### PR DESCRIPTION
- Use global `hugo` function (`.Page.Hugo` is deprecated)
- Use global `site` function
- Use .File.UniqueID (`.Page.UniqueID` is deprecated)
- Fix missing menu entries (https://github.com/gohugoio/hugo/issues/5828)