### PR TITLE
Add Netlify _redirects support

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -3,13 +3,28 @@ languageCode = "en-us"
 title = "LT OSP Field Guide"
 theme = ["lt-osp", "fuse-search"]
 
+[outputFormats]
+  [outputFormats.NetlifyRedirects]
+    name = "_Redirects"
+    baseName = "_redirects"
+    isPlainText = true
+    notAlternative = true
+
+[outputs]
+  home = ["HTML", "_Redirects"]
+
 [taxonomies]
   guild = "guilds"
 
-[params]
+[Params]
   themeColor = "theme-base-09"
   description = "An interactive pocket guide to the Lorien Trust Role-Playing (L.T.R.P.) System's Occupational Skill Points v3.1.1"
   copyright = "Copyright 2019 Adam Scott and Phill Sparks. All rights reserved."
+  [Params.Redirects]
+    Gone = []
+    [Params.Redirects.Custom]
+      "https://compassionate-aryabhata-ce7373.netlify.com/*" = "https://ltosp.uk/:splat"
+
 
 [[menu.guilds]]
   name = "General"

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,2 +1,0 @@
-# Redirect default Netlify subdomain to primary domain
-https://compassionate-aryabhata-ce7373.netlify.com/* https://ltosp.uk/:splat 301!

--- a/themes/lt-osp/layouts/home._redirects
+++ b/themes/lt-osp/layouts/home._redirects
@@ -1,0 +1,21 @@
+{{- with site.Params.Redirects.Custom }}
+# Custom Redirects
+{{- range $from, $to := . }}
+{{ $from }}  {{ $to }}
+{{- end }}
+{{- end }}
+
+# Page Aliases
+{{- range .Site.Pages }}
+{{- $page := . -}}
+{{- range .Aliases }}
+{{  . | printf "%-35s" }}  {{ $page.RelPermalink }}  301!
+{{- end }}
+{{- end }}
+
+{{- with site.Params.Redirects.Gone }}
+# Gone
+{{- range . }}
+{{ . }}  /404.html  410
+{{- end }}
+{{- end }}


### PR DESCRIPTION
Requires that all redirects are absolute (no relative redirects) - this is because there's no way to generate a relative link based on a page to somewhere that does not exist.