### PR TITLE
Update Revive and Revitalise Unliving trees

### DIFF
--- a/content/help/key.md
+++ b/content/help/key.md
@@ -4,7 +4,7 @@ title: "Key"
 
 |Item|Description|
 |----|-----------|
-|{{< cell id="skill-1" >}}Skill{{</ cell >}}|A new entry on your character card|
+|{{< cell id="help-1" >}}Skill{{</ cell >}}|A new entry on your character card|
 ||Arrows lead from pre-requisite skills|
-|{{< cell prerequisite="skill-1" replacement="yes" title="Replacement Skill" >}}Replacement{{</ cell >}}|Replaces another skill on your character card|
+|{{< cell prerequisite="help-1" replacement="yes" title="Replacement Skill" >}}Replacement{{</ cell >}}|Replaces another skill on your character card|
 |{{< cell restricted="yes" title="Restricted Skill #" >}}Restricted{{</ cell >}}|Must be taught by a tutor|

--- a/content/skill/advanced-healing.md
+++ b/content/skill/advanced-healing.md
@@ -8,6 +8,6 @@ requirements: ["Healing CS"]
 replacement: true
 ladder: "revive"
 ---
-This skill replaces the [Revive OS][revive] and allows a character to extend a Chant of Heal Wound to affect every location on a single character, without requiring extra spell cards. The healing is location by location, not simultaneous and the healer may choose what damage to heal first. Contact with any part of the target is sufficient and the spell functions in all other ways as normal.
+This skill replaces the [Revive][revive] Occupational Skill and allows a character to extend a Chant of Heal Wound to affect every location on a single character, without requiring extra spell Power. The healing is location by location, not simultaneous and the healer may choose what damage to heal first.
 
 [revive]: {{< ref "revive" >}}

--- a/content/skill/beguile.md
+++ b/content/skill/beguile.md
@@ -7,7 +7,7 @@ prerequisites: ["cast-mass-charms", " & ", "detect-and-remove-beguile"]
 requirements: []
 replacement: true
 restricted: true
-ladder: "detect-and-remove-beguile"
+ladder: "beguile-2"
 ---
 This skill replaces the [Detect and Remove Beguile][detect-and-remove-beguile] Occupational Skill. The character has the ability to detect and remove the Beguile effect. To detect if an individual is under the influence of a Beguile, the character must engage them in meaningful conversation for at least 30 seconds, after which they may make the call “detect beguile”. To remove a Beguile it must be detected as above, the character must then continue the conversation for another thirty seconds. At the end of this period all effects of the Beguile are removed. This ability requires concentration. The character also may use 4 spell Power to create an innate Beguile effect after 5 minutes of meaningful two-way conversation with their intended target. This effect cannot be countered and the OOC call is “innate beguile”. Note: this is an effect and not a spell and may not be combined with Spell Reduction.
 

--- a/content/skill/cast-mass-charms.md
+++ b/content/skill/cast-mass-charms.md
@@ -6,7 +6,7 @@ osp_cost: 40
 prerequisites: ["immune-to-charms"]
 requirements: []
 replacement: true
-ladder: "detect-and-remove-beguile"
+ladder: "beguile"
 ---
 This skill replaces the [Immune to Charms][immune-to-charms] Occupational Skill. The character is immune to all charm effects (Befriend, Beguile, Enthral and Enthral Unliving). The character may also change the effects Befriend, Enthral or Enthral Unliving into mass effects, if they are capable of casting them. This requires 4 power to cast as a level 3 spell effect. The enhanced spell counts in all ways as a mass spell and therefore cannot be countered. The vocals for the spell are “By the High power of True Song I mass Befriend you all/Enthral you all/Enthral Unliving”. Note: this effect may not be combined with Spell Reduction (regardless of source).
 

--- a/content/skill/detect-and-remove-beguile.md
+++ b/content/skill/detect-and-remove-beguile.md
@@ -5,6 +5,6 @@ tier: 2
 osp_cost: 20
 prerequisites: []
 requirements: []
-ladder: "detect-and-remove-beguile"
+ladder: "beguile"
 ---
 This skill gives a character the ability to detect and remove the Beguile effect on another character. To detect if an individual is under the influence of a Beguile, the character must engage them in meaningful conversation for at least 30 seconds, after which they may make the call “detect beguile”. To remove a Beguile it must be detected as above, the character must then continue the conversation for another thirty seconds. At the end of this period all effects of the Beguile are removed. This ability requires concentration.

--- a/content/skill/immune-to-charms.md
+++ b/content/skill/immune-to-charms.md
@@ -5,6 +5,6 @@ tier: 3
 osp_cost: 30
 prerequisites: ["detect-and-remove-beguile"]
 requirements: []
-ladder: "detect-and-remove-beguile"
+ladder: "beguile"
 ---
 This skill makes the character immune to all charm effects. Charms are a sub group of Mind effects and include Befriend, Beguile, Enthral and Enthral Unliving.

--- a/content/skill/mind-healing.md
+++ b/content/skill/mind-healing.md
@@ -5,6 +5,6 @@ tier: 4
 osp_cost: 40
 prerequisites: ["advanced-healing", " (Healers)", " / ", "repair-unliving-advanced", " (Corruptors)"]
 requirements: []
-ladder: "revive"
+ladder: "revive-2"
 ---
 A character with this skill may extend the Discerning Wounds vocal to include the detection of mind effects. This detection effect requires a minimum of 10 seconds whilst holding a hand in proximity range of the target and using the vocals **"Discern Wound, Poison, Pattern Effect, Disease or Mind Effect"**. The character with this skill may also add to any non-instant Cure spell (in the Cure Category) with the the additional vocal **"and also remove any Mind Effects from your pattern"**. If this spell (and additional vocal) is maintained for a minimum of 30 seconds the character will remove all Mind effects from the target. Using this ability requires concentration. In addition the character is immune to the Sleep effect.

--- a/content/skill/mind-healing.md
+++ b/content/skill/mind-healing.md
@@ -1,10 +1,10 @@
 ---
 title: "Mind Healing"
-guilds: [healers]
+guilds: [corruptors, healers]
 tier: 4
 osp_cost: 40
-prerequisites: ["advanced-healing"]
-requirements: ["Healing CS"]
+prerequisites: ["advanced-healing", " (Healers)", " / ", "repair-unliving-advanced", " (Corruptors)"]
+requirements: []
 ladder: "revive"
 ---
-This skill gives a character the ability to detect and remove all Mind effects. To detect if an individual is under the influence of any Mind effect, the character must engage them in sensible conversation for at least 30 seconds, after which they may make the call “discern mind effect”. To remove a discerned Mind effect, the character must continue the conversation for at least a further minute. At the end of this period the Mind effect is removed. Using this ability requires concentration.
+A character with this skill may extend the Discerning Wounds vocal to include the detection of mind effects. This detection effect requires a minimum of 10 seconds whilst holding a hand in proximity range of the target and using the vocals **"Discern Wound, Poison, Pattern Effect, Disease or Mind Effect"**. The character with this skill may also add to any non-instant Cure spell (in the Cure Category) with the the additional vocal **"and also remove any Mind Effects from your pattern"**. If this spell (and additional vocal) is maintained for a minimum of 30 seconds the character will remove all Mind effects from the target. Using this ability requires concentration. In addition the character is immune to the Sleep effect.

--- a/content/skill/rally.md
+++ b/content/skill/rally.md
@@ -7,7 +7,7 @@ prerequisites: ["immune-to-mute", " & ", "immune-to-fear"]
 requirements: []
 replacement: true
 restricted: true
-ladder: "immune-to-fear"
+ladder: "immune-to-fear-2"
 ---
 This skill replaces the [Immune to Fear][immune-to-fear] Occupational Skill and the character is immune to the Fear effect. Additionally, the character gains the ability to cast the spell Rally using their own power. If the character already has the ability to cast the spell, they will gain Spell Reduction (3) for the Rally Spell. Alternatively, If the character has no spellcasting character skills or have expended all of their \[power\] for the day, they may instead cast the Rally spell (for no power cost) once per 10 min. Once you have used this ability you cannot use it again for 10 mins.
 

--- a/content/skill/repair-unliving-advanced.md
+++ b/content/skill/repair-unliving-advanced.md
@@ -4,11 +4,10 @@ guilds: [corruptors]
 tier: 2
 osp_cost: 20
 prerequisites: ["revitalise-unliving"]
-requirements: ["corruption", " OS"]
+requirements: ["Repair Unliving Spell"]
 replacement: true
-restricted: true
-ladder: "revitalise-unliving"
+ladder: "revive"
 ---
-This skill replaces the [Revitalise Unliving OS][revitalise-unliving] and allows a character to extend a Chant of Repair Unliving to every location on a single character, for no additional spell cards. The repair is location by location, not simultaneous and the repairer may choose what damage to repair first. Contact with any part of the target is sufficient and the spell functions in all other ways as normal.
+This skill replaces the [Revitalise Unliving][revitalise-unliving] Occupational Skill and allows a character to extend a Chant of Repair Unliving to affect every location on a single character, without requiring extra Spell Power. The repair is location by location, not simultaneous and the Corruptor may choose what damage to repair first. Contact with any part of the target is sufficient and the spell functions in all other ways as normal.
 
 [revitalise-unliving]: {{< ref "revitalise-unliving" >}}

--- a/content/skill/revitalise-unliving.md
+++ b/content/skill/revitalise-unliving.md
@@ -4,8 +4,7 @@ guilds: [corruptors]
 tier: 1
 osp_cost: 10
 prerequisites: []
-requirements: ["corruption", " OS"]
-restricted: true
-ladder: "revitalise-unliving"
+requirements: ["Repair Unliving Spell"]
+ladder: "revive"
 ---
-This skill allows a character to extend a Chant of Repair Unliving to every location on a single character, for no additional spell cards. The repair is location by location, not simultaneous and the repairer may choose what damage to repair first. Contact with any part of the target is sufficient but the Chant of Repair Unliving cannot heal any location with a mortal wound, these must be repaired separately. The spell functions in all other ways as normal.
+This skill allows a character to extend a Repair Unliving to every location on a single character, for no additional Spell Power. The repair is location by location, not simultaneous and the Corruptor may choose what damage to repair first. Contact with any part of the target is sufficient but the Chant of Repair Unliving cannot repair any location with a mortal wound, these must be repaired separately. The spell functions in all other ways as normal.

--- a/content/skill/revive.md
+++ b/content/skill/revive.md
@@ -7,4 +7,4 @@ prerequisites: []
 requirements: ["Healing CS"]
 ladder: "revive"
 ---
-This skill allows a character to extend a Chant of Heal Wounds to every location on a single character, for no additional spell cards. The healing is location by location, not simultaneous and the healer may choose what damage to heal first. Contact with any part of the target is sufficient but the Chant of Heal Wounds cannot heal any location with a mortal wound, these must be healed separately. The spell functions in all other ways as normal.
+This skill allows a character to extend a Chant of Heal Wounds to every location on a single character, for no additional Spell Power. The healing is location by location, not simultaneous and the healer may choose what damage to heal first. Contact with any part of the target is sufficient but the Chant of Heal Wounds cannot heal any location with a mortal wound, these must be healed separately. The spell functions in all other ways as normal.

--- a/content/skill/source-of-life.md
+++ b/content/skill/source-of-life.md
@@ -4,11 +4,14 @@ guilds: [healers]
 tier: 5
 osp_cost: 50
 prerequisites: ["mind-healing", " & ", "advanced-healing"]
-requirements: ["Healing CS", " and ", "high-magic-x", " OS"]
+requirements: ["Level 2 Healing CS"]
 replacement: true
 restricted: true
 ladder: "revive"
 ---
-This skill replaces the [Advanced Healing OS][advanced-healing] and a character with this skill has Spell Reduction (3) for the spell Total Heal.
+This skill replaces the [Advanced Healing][advanced-healing] Occupational Skill, and includes the [Mind Healing][mind-healing] Occupational Skill. It also allows the character to cast the Total Heal Spell without having the requirement of the [High Magic][high-magic] Occupational Skill. If the character gains the [High Magic (Healing)][high-magic-healing] Occupational Skill, they gain Spell Reduction (3) for the spell Total Heal.
 
 [advanced-healing]: {{< ref "advanced-healing" >}}
+[high-magic]: {{< ref "high-magic-x" >}}
+[high-magic-healing]: {{< ref "high-magic-x" >}}
+[mind-healing]: {{< ref "mind-healing" >}}

--- a/content/skill/source-of-unlife.md
+++ b/content/skill/source-of-unlife.md
@@ -3,12 +3,15 @@ title: "Source of Unlife"
 guilds: [corruptors]
 tier: 5
 osp_cost: 50
-prerequisites: ["repair-unliving-advanced"]
-requirements: ["high-magic-x", " and ", "corruption", " OS", " and ", "Healing CS"]
+prerequisites: ["mind-healing", " & ", "repair-unliving-advanced"]
+requirements: ["Level 2 Corruption CS"]
 replacement: true
 restricted: true
-ladder: "revitalise-unliving"
+ladder: "revive"
 ---
-This skill replaces the [Repair Unliving (Advanced) OS][repair-unliving-advanced]. After Chanting for 10 seconds whilst touching the target, a character with this OS can restore all locations on a single Unliving target to full body hits (LHV). It costs 2 spell cards to use this ability. Note: this ability is not a spell, and may not be combined with Spell Reduction
+This skill replaces the [Repair Unliving (Advanced)][repair-unliving-advanced] Occupational Skill and includes the [Mind Healing][mind-healing] Occupational Skill. It also allows the character to cast the Total Repair Unliving Spell without having the requirement of the [High Magic][high-magic] Occupational Skill. If the character gains the [High Magic (Corruption)][high-magic-corruption] Occupational Skill, they gain Spell Reduction (3) for the spell Total Repair Unliving.
 
+[high-magic]: {{< ref "high-magic-x" >}}
+[high-magic-corruption]: {{< ref "high-magic-x" >}}
+[mind-healing]: {{< ref "mind-healing" >}}
 [repair-unliving-advanced]: {{< ref "repair-unliving-advanced" >}}

--- a/themes/lt-osp/assets/js/taxonomy.js
+++ b/themes/lt-osp/assets/js/taxonomy.js
@@ -38,11 +38,11 @@ onReady(function () {
             evt.target.focus();
         });
 
-        if (!cell.dataset.prerequisite) {
+        if (!cell.dataset.prerequisites) {
             return;
         }
 
-        var prerequisites = cell.dataset.prerequisite.split(";");
+        var prerequisites = cell.dataset.prerequisites.split(";");
         prerequisites.forEach(function (prerequisiteId) {
             var prerequisite = document.getElementById(prerequisiteId);
             if (!prerequisite) {

--- a/themes/lt-osp/layouts/shortcodes/cell.html
+++ b/themes/lt-osp/layouts/shortcodes/cell.html
@@ -1,4 +1,4 @@
 <a href="#" title="{{ default .Inner (.Get "title") }}"
     class="cell{{ with .Get "replacement" }} replacement-cell{{ end }}{{ with .Get "restricted" }} restricted-cell{{ end }}"
-    {{ with .Get "id" }}id="{{ . }}" {{ end }} {{ with .Get "prerequisite" }}data-prerequisite="{{ . }}" {{ end }}>
+    {{ with .Get "id" }}id="{{ . }}" {{ end }} {{ with .Get "prerequisite" }}data-prerequisites="{{ . }}" {{ end }}>
     {{- .Inner -}}</a>

--- a/themes/lt-osp/layouts/skill/cell.html
+++ b/themes/lt-osp/layouts/skill/cell.html
@@ -1,6 +1,7 @@
 <a class="cell cell-{{ .Type }}{{ if .Params.restricted }} restricted-cell{{ end }}{{ if .Params.replacement }} replacement-cell{{ end }}"
-    id="{{ .Type }}-{{ .File.UniqueID }}" href="{{ .Permalink }}" title="{{ .Title }}"
-    {{ range .Params.prerequisites }}{{- with site.GetPage (printf "/skill/%s" .) }}
-    data-prerequisite="{{ .Type }}-{{ .File.UniqueID }}" {{ end }}{{ end }}>
-    {{ .LinkTitle }}
+    id="{{ .Type }}-{{ .File.UniqueID }}" href="{{ .Permalink }}" title="{{ .Title }}" {{- $prerequisites := slice }}
+    {{- range .Params.prerequisites }}{{- with site.GetPage (printf "/skill/%s" .) }}
+    {{- $prerequisites = $prerequisites | append (print .Type "-" .File.UniqueID) }} {{ end }}{{ end }}
+    {{- with $prerequisites }}data-prerequisites="{{ delimit . ";" }}" {{ end }}>
+    {{- .LinkTitle -}}
 </a>


### PR DESCRIPTION
These skills are from the Healing and Corruption guilds and both trees share Mind Healing (Tier 4) with different pre-requisites. 
 Along with the skill updates I've also changed the theme to display all pre-requisites on the table. I've also made a few column changes to other affected skills to make it clearer that there are multiple pre-requisites.

Fixes https://github.com/sparksp/lt-osp/issues/28