### PR TITLE
Add Omega to Guild lists

### DIFF
--- a/content/lists/alchemists-guild/_index.md
+++ b/content/lists/alchemists-guild/_index.md
@@ -1,5 +1,6 @@
 ---
-title: "Alchemists"
+title: "Alchemists Guild Ω"
+linktitle: "Alchemists Guild"
 aliases:
     - /guilds/alchemists/
 menu:

--- a/content/lists/arcane-guilds/_index.md
+++ b/content/lists/arcane-guilds/_index.md
@@ -1,5 +1,6 @@
 ---
-title: "Arcane Guilds"
+title: "Arcane Guilds Ω"
+linktitle: "Arcane Guilds"
 aliases:
     - /guilds/arcane-guilds/
     - /guilds/powers-or-magic-guilds/

--- a/content/lists/armourers-guild/_index.md
+++ b/content/lists/armourers-guild/_index.md
@@ -1,5 +1,6 @@
 ---
-title: "Armourers"
+title: "Armourers Guild Ω"
+linktitle: "Armourers Guild"
 aliases:
     - /guilds/armourers/
 menu:

--- a/content/lists/bards-guild/_index.md
+++ b/content/lists/bards-guild/_index.md
@@ -1,5 +1,6 @@
 ---
-title: "Bards"
+title: "Bards Guild Ω"
+linktitle: "Bards Guild"
 aliases:
     - /guilds/bards/
 menu:

--- a/content/lists/casino-guild/_index.md
+++ b/content/lists/casino-guild/_index.md
@@ -1,5 +1,6 @@
 ---
-title: "Casino"
+title: "Casino Guild Ω"
+linktitle: "Casino Guild"
 aliases:
     - /guilds/casino/
 menu:

--- a/content/lists/corruptors-guild/_index.md
+++ b/content/lists/corruptors-guild/_index.md
@@ -1,5 +1,6 @@
 ---
-title: "Corruptors"
+title: "Corruptors Guild Ω"
+linktitle: "Corruptors Guild"
 aliases:
     - /guilds/corruptors/
 menu:

--- a/content/lists/healers-guild/_index.md
+++ b/content/lists/healers-guild/_index.md
@@ -1,5 +1,6 @@
 ---
-title: "Healers"
+title: "Healers Guild Ω"
+linktitle: "Healers Guild"
 aliases:
     - /guilds/healers/
 menu:

--- a/content/lists/incantors-guild/_index.md
+++ b/content/lists/incantors-guild/_index.md
@@ -1,5 +1,6 @@
 ---
-title: "Incantors"
+title: "Incantors Guild Ω"
+linktitle: "Incantors Guild"
 aliases:
     - /guilds/incantors/
 menu:

--- a/content/lists/knowledge-guilds/_index.md
+++ b/content/lists/knowledge-guilds/_index.md
@@ -1,5 +1,6 @@
 ---
-title: "Knowledge Guilds"
+title: "Knowledge Guilds Ω"
+linktitle: "Knowledge Guilds"
 aliases:
     - /guilds/knowledge-guilds/
 menu:

--- a/content/lists/mages-guild/_index.md
+++ b/content/lists/mages-guild/_index.md
@@ -1,5 +1,6 @@
 ---
-title: "Mages"
+title: "Mages Guild Ω"
+linktitle: "Mages Guild"
 aliases:
     - /guilds/mages/
 menu:

--- a/content/lists/martial-guilds/_index.md
+++ b/content/lists/martial-guilds/_index.md
@@ -1,5 +1,6 @@
 ---
-title: "Martial Guilds"
+title: "Martial Guilds Ω"
+linktitle: "Martial Guilds"
 aliases:
     - /guilds/martial-guilds/
 menu:

--- a/content/lists/militia-guild/_index.md
+++ b/content/lists/militia-guild/_index.md
@@ -1,5 +1,6 @@
 ---
-title: "Militia"
+title: "Militia Guild Ω"
+linktitle: "Militia Guild"
 aliases:
     - /guilds/militia/
 menu:

--- a/content/lists/rangers-guild/_index.md
+++ b/content/lists/rangers-guild/_index.md
@@ -1,5 +1,6 @@
 ---
-title: "Rangers"
+title: "Rangers Guild Ω"
+linktitle: "Rangers Guild"
 aliases:
     - /guilds/archers/
     - /guilds/rangers/

--- a/content/lists/scouts-guild/_index.md
+++ b/content/lists/scouts-guild/_index.md
@@ -1,5 +1,6 @@
 ---
-title: "Scouts"
+title: "Scouts Guild Ω"
+linktitle: "Scouts Guild"
 aliases:
     - /guilds/scouts/
 menu:

--- a/content/skill/additional-reforging.md
+++ b/content/skill/additional-reforging.md
@@ -1,7 +1,7 @@
 ---
 title: "Additional Reforging"
 lists:
-    - armourers
+    - armourers-guild
 tier: 1
 osp_cost: 10
 prerequisites: []

--- a/content/skill/advanced-healing.md
+++ b/content/skill/advanced-healing.md
@@ -1,7 +1,7 @@
 ---
 title: "Advanced Healing"
 lists:
-    - healers
+    - healers-guild
 tier: 2
 osp_cost: 20
 prerequisites: ["revive"]

--- a/content/skill/advanced-pattern-scan.md
+++ b/content/skill/advanced-pattern-scan.md
@@ -1,7 +1,7 @@
 ---
 title: "Advanced Pattern Scan"
 lists:
-    - healers
+    - healers-guild
 tier: 4
 osp_cost: 40
 prerequisites: ["discern-pattern-type"]

--- a/content/skill/armoursmith-apprentice.md
+++ b/content/skill/armoursmith-apprentice.md
@@ -1,7 +1,7 @@
 ---
 title: "Armoursmith (Apprentice)"
 lists:
-    - armourers
+    - armourers-guild
 tier: 1
 osp_cost: 10
 prerequisites: []

--- a/content/skill/armoursmith-artisan.md
+++ b/content/skill/armoursmith-artisan.md
@@ -1,7 +1,7 @@
 ---
 title: "Armoursmith (Artisan)"
 lists:
-    - armourers
+    - armourers-guild
 tier: 4
 osp_cost: 40
 prerequisites: ["repair-enchanted-items"]

--- a/content/skill/armoursmith-master.md
+++ b/content/skill/armoursmith-master.md
@@ -1,7 +1,7 @@
 ---
 title: "Armoursmith (Master)"
 lists:
-    - armourers
+    - armourers-guild
 tier: 5
 osp_cost: 50
 prerequisites: ["armoursmith-artisan"]

--- a/content/skill/beguile.md
+++ b/content/skill/beguile.md
@@ -1,7 +1,7 @@
 ---
 title: "Beguile"
 lists:
-    - bards
+    - bards-guild
 tier: 5
 osp_cost: 50
 prerequisites: ["cast-mass-charms", " & ", "detect-and-remove-beguile"]

--- a/content/skill/bowyer-apprentice.md
+++ b/content/skill/bowyer-apprentice.md
@@ -1,7 +1,7 @@
 ---
 title: "Bowyer (Apprentice)"
 lists:
-    - rangers
+    - rangers-guild
 tier: 2
 osp_cost: 20
 prerequisites: []

--- a/content/skill/bowyer-master.md
+++ b/content/skill/bowyer-master.md
@@ -3,7 +3,7 @@ title: "Bowyer (Master)"
 aliases:
     - /skill/bowyer-artisan/
 lists:
-    - rangers
+    - rangers-guild
 tier: 4
 osp_cost: 40
 prerequisites: ["bowyer-apprentice"]

--- a/content/skill/cast-additional-incantation.md
+++ b/content/skill/cast-additional-incantation.md
@@ -1,7 +1,7 @@
 ---
 title: "Cast Additional Incantation"
 lists:
-    - incantors
+    - incantors-guild
 tier: 5
 osp_cost: 50
 prerequisites: ["last-rites-improved", " or ", "master-countermagic"]

--- a/content/skill/cast-additional-magecraft.md
+++ b/content/skill/cast-additional-magecraft.md
@@ -1,7 +1,7 @@
 ---
 title: "Cast Additional Magecraft"
 lists:
-    - mages
+    - mages-guild
 tier: 5
 osp_cost: 50
 prerequisites: ["master-countermagic"]

--- a/content/skill/cast-high-countermagic.md
+++ b/content/skill/cast-high-countermagic.md
@@ -1,7 +1,7 @@
 ---
 title: "Cast High Countermagic"
 lists:
-    - incantors
+    - incantors-guild
     - mages
 tier: 3
 osp_cost: 30

--- a/content/skill/cast-high-countermagic.md
+++ b/content/skill/cast-high-countermagic.md
@@ -2,7 +2,7 @@
 title: "Cast High Countermagic"
 lists:
     - incantors-guild
-    - mages
+    - mages-guild
 tier: 3
 osp_cost: 30
 prerequisites: []

--- a/content/skill/cast-mass-charms.md
+++ b/content/skill/cast-mass-charms.md
@@ -1,7 +1,7 @@
 ---
 title: "Cast Mass Charms"
 lists:
-    - bards
+    - bards-guild
     - casino
 tier: 4
 osp_cost: 40

--- a/content/skill/cast-mass-charms.md
+++ b/content/skill/cast-mass-charms.md
@@ -2,7 +2,7 @@
 title: "Cast Mass Charms"
 lists:
     - bards-guild
-    - casino
+    - casino-guild
 tier: 4
 osp_cost: 40
 prerequisites: ["immune-to-charms"]

--- a/content/skill/champion.md
+++ b/content/skill/champion.md
@@ -2,7 +2,7 @@
 title: "Champion"
 lists:
     - incantors-guild
-    - mages
+    - mages-guild
 tier: 4
 osp_cost: 40
 prerequisites: ["transcend-armour"]

--- a/content/skill/champion.md
+++ b/content/skill/champion.md
@@ -1,7 +1,7 @@
 ---
 title: "Champion"
 lists:
-    - incantors
+    - incantors-guild
     - mages
 tier: 4
 osp_cost: 40

--- a/content/skill/conceal-item-improved.md
+++ b/content/skill/conceal-item-improved.md
@@ -1,7 +1,7 @@
 ---
 title: "Conceal Item (Improved)"
 lists:
-    - casino
+    - casino-guild
 tier: 3
 osp_cost: 30
 prerequisites: [conceal-item]

--- a/content/skill/conceal-item.md
+++ b/content/skill/conceal-item.md
@@ -1,7 +1,7 @@
 ---
 title: "Conceal Item"
 lists:
-    - casino
+    - casino-guild
     - scouts
 tier: 2
 osp_cost: 20

--- a/content/skill/conceal-item.md
+++ b/content/skill/conceal-item.md
@@ -2,7 +2,7 @@
 title: "Conceal Item"
 lists:
     - casino-guild
-    - scouts
+    - scouts-guild
 tier: 2
 osp_cost: 20
 prerequisites: []

--- a/content/skill/contribute-to-2nd-ritual.md
+++ b/content/skill/contribute-to-2nd-ritual.md
@@ -1,7 +1,7 @@
 ---
 title: "Contribute to 2nd Ritual"
 lists:
-    - mages
+    - mages-guild
 tier: 1
 osp_cost: 10
 prerequisites: []

--- a/content/skill/contribute-to-3rd-ritual.md
+++ b/content/skill/contribute-to-3rd-ritual.md
@@ -1,7 +1,7 @@
 ---
 title: "Contribute to 3rd Ritual"
 lists:
-    - mages
+    - mages-guild
 tier: 3
 osp_cost: 30
 prerequisites: ["contribute-to-2nd-ritual"]

--- a/content/skill/create-antidotes-improved.md
+++ b/content/skill/create-antidotes-improved.md
@@ -1,7 +1,7 @@
 ---
 title: "Create Antidotes (Improved)"
 lists:
-    - alchemists
+    - alchemists-guild
 tier: 3
 osp_cost: 30
 prerequisites: ["create-antidotes"]

--- a/content/skill/create-antidotes.md
+++ b/content/skill/create-antidotes.md
@@ -1,7 +1,7 @@
 ---
 title: "Create Antidotes"
 lists:
-    - alchemists
+    - alchemists-guild
 tier: 1
 osp_cost: 10
 prerequisites: ["Poison Lore", " or ", "Potion Lore CS"]

--- a/content/skill/create-poison-artisan.md
+++ b/content/skill/create-poison-artisan.md
@@ -3,7 +3,7 @@ title: "Create Poison (Artisan)"
 aliases:
     - /skill/create-poison-2/
 lists:
-    - alchemists
+    - alchemists-guild
 tier: 3
 osp_cost: 30
 prerequisites: ["create-poison-novice", " & ", "Poison Lore"]

--- a/content/skill/create-poison-magical.md
+++ b/content/skill/create-poison-magical.md
@@ -3,7 +3,7 @@ title: "Create Poison (Magical)"
 aliases:
     - /skill/create-magical-poison/
 lists:
-    - alchemists
+    - alchemists-guild
 tier: 5
 osp_cost: 50
 prerequisites: ["create-poison-master", " & ", "Poison Lore"]

--- a/content/skill/create-poison-master.md
+++ b/content/skill/create-poison-master.md
@@ -3,7 +3,7 @@ title: "Create Poison (Master)"
 aliases:
     - /skill/create-poison-3/
 lists:
-    - alchemists
+    - alchemists-guild
 tier: 4
 osp_cost: 40
 prerequisites: ["create-poison-artisan", " & ", "Poison Lore"]

--- a/content/skill/create-poison-novice.md
+++ b/content/skill/create-poison-novice.md
@@ -3,7 +3,7 @@ title: "Create Poison (Novice)"
 aliases:
     - /skill/create-poison-1/
 lists:
-    - alchemists
+    - alchemists-guild
 tier: 2
 osp_cost: 20
 prerequisites: ["Poison Lore"]

--- a/content/skill/create-potion-artisan.md
+++ b/content/skill/create-potion-artisan.md
@@ -3,7 +3,7 @@ title: "Create Potion (Artisan)"
 aliases:
     - /skill/create-potion-2/
 lists:
-    - alchemists
+    - alchemists-guild
 tier: 3
 osp_cost: 30
 prerequisites: ["create-potion-novice", " & ", "Potion Lore"]

--- a/content/skill/create-potion-magical.md
+++ b/content/skill/create-potion-magical.md
@@ -3,7 +3,7 @@ title: "Create Potion (Magical)"
 aliases:
     - /skill/create-magical-potion/
 lists:
-    - alchemists
+    - alchemists-guild
 tier: 5
 osp_cost: 50
 prerequisites: ["create-potion-master", " & ", "Potion Lore"]

--- a/content/skill/create-potion-master.md
+++ b/content/skill/create-potion-master.md
@@ -3,7 +3,7 @@ title: "Create Potion (Master)"
 aliases:
     - /skill/create-potion-3/
 lists:
-    - alchemists
+    - alchemists-guild
 tier: 4
 osp_cost: 40
 prerequisites: ["create-potion-artisan", " & ", "Potion Lore"]

--- a/content/skill/create-potion-novice.md
+++ b/content/skill/create-potion-novice.md
@@ -3,7 +3,7 @@ title: "Create Potion (Novice)"
 aliases:
     - /skill/create-potion-1/
 lists:
-    - alchemists
+    - alchemists-guild
 tier: 2
 osp_cost: 20
 prerequisites: ["Potion Lore"]

--- a/content/skill/create-reagents-improved.md
+++ b/content/skill/create-reagents-improved.md
@@ -1,7 +1,7 @@
 ---
 title: "Create Reagents (Improved)"
 lists:
-    - alchemists
+    - alchemists-guild
 tier: 2
 osp_cost: 30
 prerequisites: ["create-reagents"]

--- a/content/skill/create-reagents.md
+++ b/content/skill/create-reagents.md
@@ -1,7 +1,7 @@
 ---
 title: "Create Reagents"
 lists:
-    - alchemists
+    - alchemists-guild
 tier: 1
 osp_cost: 10
 prerequisites: ["Poison Lore", " or ", "Potion Lore CS"]

--- a/content/skill/crushing-blow.md
+++ b/content/skill/crushing-blow.md
@@ -1,7 +1,7 @@
 ---
 title: "Crushing Blow"
 lists:
-    - armourers
+    - armourers-guild
     - militia
 tier: 5
 osp_cost: 50

--- a/content/skill/crushing-blow.md
+++ b/content/skill/crushing-blow.md
@@ -2,7 +2,7 @@
 title: "Crushing Blow"
 lists:
     - armourers-guild
-    - militia
+    - militia-guild
 tier: 5
 osp_cost: 50
 prerequisites: ["mighty-blow"]

--- a/content/skill/damage-reduction-fatal.md
+++ b/content/skill/damage-reduction-fatal.md
@@ -1,7 +1,7 @@
 ---
 title: "Damage Reduction (Fatal)"
 lists:
-    - incantors
+    - incantors-guild
 tier: 5
 osp_cost: 50
 prerequisites: ["dedicated-follower"]

--- a/content/skill/dedicated-follower.md
+++ b/content/skill/dedicated-follower.md
@@ -1,7 +1,7 @@
 ---
 title: "Dedicated Follower"
 lists:
-    - incantors
+    - incantors-guild
 tier: 3
 osp_cost: 30
 prerequisites: []

--- a/content/skill/detect-and-remove-beguile.md
+++ b/content/skill/detect-and-remove-beguile.md
@@ -1,7 +1,7 @@
 ---
 title: "Detect and Remove Beguile"
 lists:
-    - bards
+    - bards-guild
     - casino
 tier: 2
 osp_cost: 20

--- a/content/skill/detect-and-remove-beguile.md
+++ b/content/skill/detect-and-remove-beguile.md
@@ -2,7 +2,7 @@
 title: "Detect and Remove Beguile"
 lists:
     - bards-guild
-    - casino
+    - casino-guild
 tier: 2
 osp_cost: 20
 prerequisites: []

--- a/content/skill/discern-ancestral-being.md
+++ b/content/skill/discern-ancestral-being.md
@@ -1,7 +1,7 @@
 ---
 title: "Discern Ancestral Being"
 lists:
-    - incantors
+    - incantors-guild
 tier: 3
 osp_cost: 30
 prerequisites: []

--- a/content/skill/discern-daemonic-being.md
+++ b/content/skill/discern-daemonic-being.md
@@ -1,7 +1,7 @@
 ---
 title: "Discern Daemonic Being"
 lists:
-    - mages
+    - mages-guild
 tier: 3
 osp_cost: 30
 prerequisites: []

--- a/content/skill/discern-elemental-being.md
+++ b/content/skill/discern-elemental-being.md
@@ -1,7 +1,7 @@
 ---
 title: "Discern Elemental Being"
 lists:
-    - healers
+    - healers-guild
 tier: 3
 osp_cost: 30
 prerequisites: []

--- a/content/skill/discern-pattern-type.md
+++ b/content/skill/discern-pattern-type.md
@@ -1,7 +1,7 @@
 ---
 title: "Discern Pattern Type"
 lists:
-    - healers
+    - healers-guild
 tier: 1
 osp_cost: 10
 prerequisites: []

--- a/content/skill/discern-race-and-pattern.md
+++ b/content/skill/discern-race-and-pattern.md
@@ -1,7 +1,7 @@
 ---
 title: "Discern Race and Pattern"
 lists:
-    - rangers
+    - rangers-guild
 tier: 4
 osp_cost: 40
 prerequisites: ["discern-race"]

--- a/content/skill/discern-race.md
+++ b/content/skill/discern-race.md
@@ -1,7 +1,7 @@
 ---
 title: "Discern Race"
 lists:
-    - rangers
+    - rangers-guild
 tier: 2
 osp_cost: 20
 prerequisites: ["tracking"]

--- a/content/skill/discern-unliving.md
+++ b/content/skill/discern-unliving.md
@@ -2,7 +2,7 @@
 title: "Discern Unliving"
 lists:
     - corruptors-guild
-    - incantors
+    - incantors-guild
 tier: 3
 osp_cost: 30
 prerequisites: []

--- a/content/skill/discern-unliving.md
+++ b/content/skill/discern-unliving.md
@@ -1,7 +1,7 @@
 ---
 title: "Discern Unliving"
 lists:
-    - corruptors
+    - corruptors-guild
     - incantors
 tier: 3
 osp_cost: 30

--- a/content/skill/dismiss-or-control-plus-2.md
+++ b/content/skill/dismiss-or-control-plus-2.md
@@ -5,7 +5,7 @@ aliases:
     - /skill/wedge-mastery/
 lists:
     - corruptors-guild
-    - incantors
+    - incantors-guild
 tier: 1
 osp_cost: 10
 prerequisites: []

--- a/content/skill/dismiss-or-control-plus-2.md
+++ b/content/skill/dismiss-or-control-plus-2.md
@@ -4,7 +4,7 @@ aliases:
     - /skill/dismiss-control-plus-2/
     - /skill/wedge-mastery/
 lists:
-    - corruptors
+    - corruptors-guild
     - incantors
 tier: 1
 osp_cost: 10

--- a/content/skill/dismiss-or-control-plus-4.md
+++ b/content/skill/dismiss-or-control-plus-4.md
@@ -4,7 +4,7 @@ aliases:
     - /skill/dismiss-control-plus-4/
 lists:
     - corruptors-guild
-    - incantors
+    - incantors-guild
 tier: 2
 osp_cost: 20
 prerequisites: ["dismiss-or-control-plus-2"]

--- a/content/skill/dismiss-or-control-plus-4.md
+++ b/content/skill/dismiss-or-control-plus-4.md
@@ -3,7 +3,7 @@ title: "Dismiss/Control +4"
 aliases:
     - /skill/dismiss-control-plus-4/
 lists:
-    - corruptors
+    - corruptors-guild
     - incantors
 tier: 2
 osp_cost: 20

--- a/content/skill/dismiss-or-control-plus-6.md
+++ b/content/skill/dismiss-or-control-plus-6.md
@@ -5,7 +5,7 @@ aliases:
     - /skill/wedge-mastery-improved/
 lists:
     - corruptors-guild
-    - incantors
+    - incantors-guild
 tier: 4
 osp_cost: 40
 prerequisites: ["dismiss-or-control-plus-4"]

--- a/content/skill/dismiss-or-control-plus-6.md
+++ b/content/skill/dismiss-or-control-plus-6.md
@@ -4,7 +4,7 @@ aliases:
     - /skill/dismiss-control-plus-6/
     - /skill/wedge-mastery-improved/
 lists:
-    - corruptors
+    - corruptors-guild
     - incantors
 tier: 4
 osp_cost: 40

--- a/content/skill/dismiss-or-control-plus-8.md
+++ b/content/skill/dismiss-or-control-plus-8.md
@@ -4,7 +4,7 @@ aliases:
     - /skill/dismiss-control-plus-8/
 lists:
     - corruptors-guild
-    - incantors
+    - incantors-guild
 tier: 5
 osp_cost: 50
 prerequisites: ["dismiss-or-control-plus-6"]

--- a/content/skill/dismiss-or-control-plus-8.md
+++ b/content/skill/dismiss-or-control-plus-8.md
@@ -3,7 +3,7 @@ title: "Dismiss/Control +8"
 aliases:
     - /skill/dismiss-control-plus-8/
 lists:
-    - corruptors
+    - corruptors-guild
     - incantors
 tier: 5
 osp_cost: 50

--- a/content/skill/enchant-projectile-weapon.md
+++ b/content/skill/enchant-projectile-weapon.md
@@ -1,7 +1,7 @@
 ---
 title: "Enchant Projectile Weapon"
 lists:
-    - rangers
+    - rangers-guild
 tier: 5
 osp_cost: 50
 prerequisites: []

--- a/content/skill/ethereal-shot.md
+++ b/content/skill/ethereal-shot.md
@@ -1,7 +1,7 @@
 ---
 title: "Ethereal Shot"
 lists:
-    - rangers
+    - rangers-guild
 tier: 5
 osp_cost: 50
 prerequisites: ["discern-race-and-pattern"]

--- a/content/skill/expert-physician.md
+++ b/content/skill/expert-physician.md
@@ -1,7 +1,7 @@
 ---
 title: "Expert Physician"
 lists:
-    - healers
+    - healers-guild
 tier: 4
 osp_cost: 40
 prerequisites: ["surgeon"]

--- a/content/skill/focused-through.md
+++ b/content/skill/focused-through.md
@@ -3,7 +3,7 @@ title: "Focused Through"
 aliases:
     - /skill/through-from-behind/
 lists:
-    - scouts
+    - scouts-guild
 tier: 2
 osp_cost: 20
 prerequisites: ["immune-to-fumble"]

--- a/content/skill/forensic-analysis.md
+++ b/content/skill/forensic-analysis.md
@@ -1,7 +1,7 @@
 ---
 title: "Forensic Analysis"
 lists:
-    - alchemists
+    - alchemists-guild
 tier: 3
 osp_cost: 30
 prerequisites: []

--- a/content/skill/forgery.md
+++ b/content/skill/forgery.md
@@ -1,7 +1,7 @@
 ---
 title: "Forgery"
 lists:
-    - bards
+    - bards-guild
     - scouts
 tier: 5
 osp_cost: 50

--- a/content/skill/forgery.md
+++ b/content/skill/forgery.md
@@ -2,7 +2,7 @@
 title: "Forgery"
 lists:
     - bards-guild
-    - scouts
+    - scouts-guild
 tier: 5
 osp_cost: 50
 prerequisites: ["written-forgery", " & ", "Recognise Forgery"]

--- a/content/skill/guarded-channelling.md
+++ b/content/skill/guarded-channelling.md
@@ -1,7 +1,7 @@
 ---
 title: "Guarded Channelling"
 lists:
-    - healers
+    - healers-guild
 tier: 5
 osp_cost: 50
 prerequisites: ["immune-to-disease"]

--- a/content/skill/halt-shot.md
+++ b/content/skill/halt-shot.md
@@ -1,7 +1,7 @@
 ---
 title: "Halt Shot"
 lists:
-    - rangers
+    - rangers-guild
 tier: 5
 osp_cost: 50
 prerequisites: ["strikedown-shot"]

--- a/content/skill/hand-of-nature.md
+++ b/content/skill/hand-of-nature.md
@@ -1,7 +1,7 @@
 ---
 title: "Hand of Nature"
 lists:
-    - rangers
+    - rangers-guild
 tier: 2
 osp_cost: 20
 prerequisites: []

--- a/content/skill/heal-alien-or-aberrant-pattern.md
+++ b/content/skill/heal-alien-or-aberrant-pattern.md
@@ -1,7 +1,7 @@
 ---
 title: "Heal Alien or Aberrant Pattern"
 lists:
-    - healers
+    - healers-guild
 tier: 3
 osp_cost: 30
 prerequisites: []

--- a/content/skill/heal-magical-pattern.md
+++ b/content/skill/heal-magical-pattern.md
@@ -1,7 +1,7 @@
 ---
 title: "Heal Magical Pattern"
 lists:
-    - healers
+    - healers-guild
 tier: 5
 osp_cost: 50
 prerequisites: ["heal-alien-or-aberrant-pattern"]

--- a/content/skill/herb-lore.md
+++ b/content/skill/herb-lore.md
@@ -2,7 +2,7 @@
 title: "Herb Lore"
 lists:
     - alchemists-guild
-    - bards
+    - bards-guild
     - healers
 tier: 1
 osp_cost: 10

--- a/content/skill/herb-lore.md
+++ b/content/skill/herb-lore.md
@@ -1,7 +1,7 @@
 ---
 title: "Herb Lore"
 lists:
-    - alchemists
+    - alchemists-guild
     - bards
     - healers
 tier: 1

--- a/content/skill/herb-lore.md
+++ b/content/skill/herb-lore.md
@@ -3,7 +3,7 @@ title: "Herb Lore"
 lists:
     - alchemists-guild
     - bards-guild
-    - healers
+    - healers-guild
 tier: 1
 osp_cost: 10
 prerequisites: []

--- a/content/skill/immune-to-befriend-and-confusion.md
+++ b/content/skill/immune-to-befriend-and-confusion.md
@@ -3,7 +3,7 @@ title: "Immune to Befriend and Confusion"
 aliases:
     - /skill/immune-to-distract-and-confusion/
 lists:
-    - bards
+    - bards-guild
     - rangers
 tier: 3
 osp_cost: 30

--- a/content/skill/immune-to-befriend-and-confusion.md
+++ b/content/skill/immune-to-befriend-and-confusion.md
@@ -4,7 +4,7 @@ aliases:
     - /skill/immune-to-distract-and-confusion/
 lists:
     - bards-guild
-    - rangers
+    - rangers-guild
 tier: 3
 osp_cost: 30
 prerequisites: []

--- a/content/skill/immune-to-charms.md
+++ b/content/skill/immune-to-charms.md
@@ -2,7 +2,7 @@
 title: "Immune to Charms"
 lists:
     - bards-guild
-    - casino
+    - casino-guild
 tier: 3
 osp_cost: 30
 prerequisites: ["detect-and-remove-beguile"]

--- a/content/skill/immune-to-charms.md
+++ b/content/skill/immune-to-charms.md
@@ -1,7 +1,7 @@
 ---
 title: "Immune to Charms"
 lists:
-    - bards
+    - bards-guild
     - casino
 tier: 3
 osp_cost: 30

--- a/content/skill/immune-to-disease.md
+++ b/content/skill/immune-to-disease.md
@@ -1,7 +1,7 @@
 ---
 title: "Immune to Disease"
 lists:
-    - corruptors
+    - corruptors-guild
     - healers
 tier: 3
 osp_cost: 30

--- a/content/skill/immune-to-disease.md
+++ b/content/skill/immune-to-disease.md
@@ -2,7 +2,7 @@
 title: "Immune to Disease"
 lists:
     - corruptors-guild
-    - healers
+    - healers-guild
 tier: 3
 osp_cost: 30
 prerequisites: []

--- a/content/skill/immune-to-fear.md
+++ b/content/skill/immune-to-fear.md
@@ -5,7 +5,7 @@ lists:
     - casino-guild
     - corruptors-guild
     - incantors-guild
-    - militia
+    - militia-guild
 tier: 1
 osp_cost: 10
 prerequisites: []

--- a/content/skill/immune-to-fear.md
+++ b/content/skill/immune-to-fear.md
@@ -3,7 +3,7 @@ title: "Immune to Fear"
 lists:
     - bards-guild
     - casino-guild
-    - corruptors
+    - corruptors-guild
     - incantors
     - militia
 tier: 1

--- a/content/skill/immune-to-fear.md
+++ b/content/skill/immune-to-fear.md
@@ -1,7 +1,7 @@
 ---
 title: "Immune to Fear"
 lists:
-    - bards
+    - bards-guild
     - casino
     - corruptors
     - incantors

--- a/content/skill/immune-to-fear.md
+++ b/content/skill/immune-to-fear.md
@@ -2,7 +2,7 @@
 title: "Immune to Fear"
 lists:
     - bards-guild
-    - casino
+    - casino-guild
     - corruptors
     - incantors
     - militia

--- a/content/skill/immune-to-fear.md
+++ b/content/skill/immune-to-fear.md
@@ -4,7 +4,7 @@ lists:
     - bards-guild
     - casino-guild
     - corruptors-guild
-    - incantors
+    - incantors-guild
     - militia
 tier: 1
 osp_cost: 10

--- a/content/skill/immune-to-fumble-and-shatter.md
+++ b/content/skill/immune-to-fumble-and-shatter.md
@@ -2,7 +2,7 @@
 title: "Immune to Fumble and Shatter"
 lists:
     - militia-guild
-    - rangers
+    - rangers-guild
 tier: 3
 osp_cost: 30
 prerequisites: ["immune-to-fumble"]

--- a/content/skill/immune-to-fumble-and-shatter.md
+++ b/content/skill/immune-to-fumble-and-shatter.md
@@ -1,7 +1,7 @@
 ---
 title: "Immune to Fumble and Shatter"
 lists:
-    - militia
+    - militia-guild
     - rangers
 tier: 3
 osp_cost: 30

--- a/content/skill/immune-to-fumble.md
+++ b/content/skill/immune-to-fumble.md
@@ -2,7 +2,7 @@
 title: "Immune to Fumble"
 lists:
     - militia-guild
-    - rangers
+    - rangers-guild
     - scouts
 tier: 1
 osp_cost: 10

--- a/content/skill/immune-to-fumble.md
+++ b/content/skill/immune-to-fumble.md
@@ -3,7 +3,7 @@ title: "Immune to Fumble"
 lists:
     - militia-guild
     - rangers-guild
-    - scouts
+    - scouts-guild
 tier: 1
 osp_cost: 10
 prerequisites: []

--- a/content/skill/immune-to-fumble.md
+++ b/content/skill/immune-to-fumble.md
@@ -1,7 +1,7 @@
 ---
 title: "Immune to Fumble"
 lists:
-    - militia
+    - militia-guild
     - rangers
     - scouts
 tier: 1

--- a/content/skill/immune-to-immobilisation.md
+++ b/content/skill/immune-to-immobilisation.md
@@ -2,7 +2,7 @@
 title: "Immune to Immobilisation"
 lists:
     - generic
-    - scouts
+    - scouts-guild
 tier: 5
 osp_cost: 50
 prerequisites: ["immune-to-repel-and-strikedown"]

--- a/content/skill/immune-to-lethal-alchemical-venoms.md
+++ b/content/skill/immune-to-lethal-alchemical-venoms.md
@@ -3,7 +3,7 @@ title: "Immune to Lethal Alchemical Venoms"
 aliases:
     - /skill/immune-to-lethal-alchemical-poisons/
 lists:
-    - alchemists
+    - alchemists-guild
 tier: 4
 osp_cost: 40
 prerequisites: []

--- a/content/skill/immune-to-mind-effects.md
+++ b/content/skill/immune-to-mind-effects.md
@@ -1,7 +1,7 @@
 ---
 title: "Immune to Mind Effects"
 lists:
-    - bards
+    - bards-guild
     - casino
     - militia
 tier: 5

--- a/content/skill/immune-to-mind-effects.md
+++ b/content/skill/immune-to-mind-effects.md
@@ -2,7 +2,7 @@
 title: "Immune to Mind Effects"
 lists:
     - bards-guild
-    - casino
+    - casino-guild
     - militia
 tier: 5
 osp_cost: 50

--- a/content/skill/immune-to-mind-effects.md
+++ b/content/skill/immune-to-mind-effects.md
@@ -3,7 +3,7 @@ title: "Immune to Mind Effects"
 lists:
     - bards-guild
     - casino-guild
-    - militia
+    - militia-guild
 tier: 5
 osp_cost: 50
 prerequisites: ["rally"]

--- a/content/skill/immune-to-mute.md
+++ b/content/skill/immune-to-mute.md
@@ -3,7 +3,7 @@ title: "Immune to Mute"
 lists:
     - bards-guild
     - casino-guild
-    - militia
+    - militia-guild
 tier: 2
 osp_cost: 20
 prerequisites: ["immune-to-fear"]

--- a/content/skill/immune-to-mute.md
+++ b/content/skill/immune-to-mute.md
@@ -2,7 +2,7 @@
 title: "Immune to Mute"
 lists:
     - bards-guild
-    - casino
+    - casino-guild
     - militia
 tier: 2
 osp_cost: 20

--- a/content/skill/immune-to-mute.md
+++ b/content/skill/immune-to-mute.md
@@ -1,7 +1,7 @@
 ---
 title: "Immune to Mute"
 lists:
-    - bards
+    - bards-guild
     - casino
     - militia
 tier: 2

--- a/content/skill/immune-to-repel-and-strikedown.md
+++ b/content/skill/immune-to-repel-and-strikedown.md
@@ -2,7 +2,7 @@
 title: "Immune to Repel and Strikedown"
 lists:
     - generic
-    - armourers
+    - armourers-guild
     - militia
     - scouts
 tier: 3

--- a/content/skill/immune-to-repel-and-strikedown.md
+++ b/content/skill/immune-to-repel-and-strikedown.md
@@ -3,7 +3,7 @@ title: "Immune to Repel and Strikedown"
 lists:
     - generic
     - armourers-guild
-    - militia
+    - militia-guild
     - scouts
 tier: 3
 osp_cost: 30

--- a/content/skill/immune-to-repel-and-strikedown.md
+++ b/content/skill/immune-to-repel-and-strikedown.md
@@ -4,7 +4,7 @@ lists:
     - generic
     - armourers-guild
     - militia-guild
-    - scouts
+    - scouts-guild
 tier: 3
 osp_cost: 30
 prerequisites: ["immune-to-repel"]

--- a/content/skill/immune-to-repel.md
+++ b/content/skill/immune-to-repel.md
@@ -3,7 +3,7 @@ title: "Immune to Repel"
 lists:
     - generic
     - armourers-guild
-    - militia
+    - militia-guild
     - scouts
 tier: 2
 osp_cost: 20

--- a/content/skill/immune-to-repel.md
+++ b/content/skill/immune-to-repel.md
@@ -4,7 +4,7 @@ lists:
     - generic
     - armourers-guild
     - militia-guild
-    - scouts
+    - scouts-guild
 tier: 2
 osp_cost: 20
 prerequisites: []

--- a/content/skill/immune-to-repel.md
+++ b/content/skill/immune-to-repel.md
@@ -2,7 +2,7 @@
 title: "Immune to Repel"
 lists:
     - generic
-    - armourers
+    - armourers-guild
     - militia
     - scouts
 tier: 2

--- a/content/skill/immune-to-sleep.md
+++ b/content/skill/immune-to-sleep.md
@@ -1,7 +1,7 @@
 ---
 title: "Immune to Sleep"
 lists:
-    - rangers
+    - rangers-guild
 tier: 4
 osp_cost: 40
 prerequisites: ["immune-to-befriend-and-confusion"]

--- a/content/skill/immune-to-through.md
+++ b/content/skill/immune-to-through.md
@@ -1,7 +1,7 @@
 ---
 title: "Immune to Through"
 lists:
-    - militia
+    - militia-guild
 tier: 4
 osp_cost: 40
 prerequisites: ["immune-to-fumble-and-shatter"]

--- a/content/skill/increased-alchemical-production.md
+++ b/content/skill/increased-alchemical-production.md
@@ -1,7 +1,7 @@
 ---
 title: "Increased Alchemical Production"
 lists:
-    - alchemists
+    - alchemists-guild
 tier: 4
 osp_cost: 40
 prerequisites: ["create-reagents-improved"]

--- a/content/skill/last-rites-improved.md
+++ b/content/skill/last-rites-improved.md
@@ -1,7 +1,7 @@
 ---
 title: "Last Rites (Improved)"
 lists:
-    - incantors
+    - incantors-guild
 tier: 4
 osp_cost: 40
 prerequisites: ["last-rites"]

--- a/content/skill/last-rites.md
+++ b/content/skill/last-rites.md
@@ -1,7 +1,7 @@
 ---
 title: "Last Rites"
 lists:
-    - incantors
+    - incantors-guild
 tier: 1
 osp_cost: 10
 prerequisites: []

--- a/content/skill/locate.md
+++ b/content/skill/locate.md
@@ -2,7 +2,7 @@
 title: "Locate"
 lists:
     - casino-guild
-    - militia
+    - militia-guild
     - scouts
 tier: 2
 osp_cost: 20

--- a/content/skill/locate.md
+++ b/content/skill/locate.md
@@ -3,7 +3,7 @@ title: "Locate"
 lists:
     - casino-guild
     - militia-guild
-    - scouts
+    - scouts-guild
 tier: 2
 osp_cost: 20
 prerequisites: []

--- a/content/skill/locate.md
+++ b/content/skill/locate.md
@@ -1,7 +1,7 @@
 ---
 title: "Locate"
 lists:
-    - casino
+    - casino-guild
     - militia
     - scouts
 tier: 2

--- a/content/skill/magic-resistance.md
+++ b/content/skill/magic-resistance.md
@@ -1,7 +1,7 @@
 ---
 title: "Magic Resistance"
 lists:
-    - militia
+    - militia-guild
 tier: 5
 osp_cost: 50
 prerequisites: ["immune-to-through"]

--- a/content/skill/master-countermagic.md
+++ b/content/skill/master-countermagic.md
@@ -2,7 +2,7 @@
 title: "Master Countermagic"
 lists:
     - incantors-guild
-    - mages
+    - mages-guild
 tier: 4
 osp_cost: 40
 prerequisites: ["cast-high-countermagic", " or ", "high-magic-x", " (Incantation or Spellcasting)"]

--- a/content/skill/master-countermagic.md
+++ b/content/skill/master-countermagic.md
@@ -1,7 +1,7 @@
 ---
 title: "Master Countermagic"
 lists:
-    - incantors
+    - incantors-guild
     - mages
 tier: 4
 osp_cost: 40

--- a/content/skill/master-poisoner.md
+++ b/content/skill/master-poisoner.md
@@ -1,7 +1,7 @@
 ---
 title: "Master Poisoner"
 lists:
-    - alchemists
+    - alchemists-guild
     - scouts
 tier: 4
 osp_cost: 40

--- a/content/skill/master-poisoner.md
+++ b/content/skill/master-poisoner.md
@@ -2,7 +2,7 @@
 title: "Master Poisoner"
 lists:
     - alchemists-guild
-    - scouts
+    - scouts-guild
 tier: 4
 osp_cost: 40
 prerequisites: []

--- a/content/skill/mighty-blow.md
+++ b/content/skill/mighty-blow.md
@@ -2,7 +2,7 @@
 title: "Mighty Blow"
 lists:
     - armourers-guild
-    - militia
+    - militia-guild
 tier: 4
 osp_cost: 40
 prerequisites: ["immune-to-repel-and-strikedown"]

--- a/content/skill/mighty-blow.md
+++ b/content/skill/mighty-blow.md
@@ -1,7 +1,7 @@
 ---
 title: "Mighty Blow"
 lists:
-    - armourers
+    - armourers-guild
     - militia
 tier: 4
 osp_cost: 40

--- a/content/skill/mind-healing.md
+++ b/content/skill/mind-healing.md
@@ -1,7 +1,7 @@
 ---
 title: "Mind Healing"
 lists:
-    - corruptors
+    - corruptors-guild
     - healers
 tier: 4
 osp_cost: 40

--- a/content/skill/mind-healing.md
+++ b/content/skill/mind-healing.md
@@ -2,7 +2,7 @@
 title: "Mind Healing"
 lists:
     - corruptors-guild
-    - healers
+    - healers-guild
 tier: 4
 osp_cost: 40
 prerequisites: ["advanced-healing", " (Healers)", " / ", "repair-unliving-advanced", " (Corruptors)"]

--- a/content/skill/mortician-expert.md
+++ b/content/skill/mortician-expert.md
@@ -1,7 +1,7 @@
 ---
 title: "Mortician (Expert)"
 lists:
-    - corruptors
+    - corruptors-guild
 tier: 4
 osp_cost: 40
 prerequisites: ["mortician"]

--- a/content/skill/mortician.md
+++ b/content/skill/mortician.md
@@ -1,7 +1,7 @@
 ---
 title: "Mortician"
 lists:
-    - corruptors
+    - corruptors-guild
 tier: 2
 osp_cost: 20
 prerequisites: []

--- a/content/skill/oiled-weapons.md
+++ b/content/skill/oiled-weapons.md
@@ -4,7 +4,7 @@ aliases:
     - /skill/oiled-arrows/
 lists:
     - alchemists-guild
-    - rangers
+    - rangers-guild
     - scouts
 tier: 3
 osp_cost: 30

--- a/content/skill/oiled-weapons.md
+++ b/content/skill/oiled-weapons.md
@@ -5,7 +5,7 @@ aliases:
 lists:
     - alchemists-guild
     - rangers-guild
-    - scouts
+    - scouts-guild
 tier: 3
 osp_cost: 30
 prerequisites: ["immune-to-fumble"]

--- a/content/skill/oiled-weapons.md
+++ b/content/skill/oiled-weapons.md
@@ -3,7 +3,7 @@ title: "Oiled Weapons"
 aliases:
     - /skill/oiled-arrows/
 lists:
-    - alchemists
+    - alchemists-guild
     - rangers
     - scouts
 tier: 3

--- a/content/skill/perform-teleport-rite.md
+++ b/content/skill/perform-teleport-rite.md
@@ -1,7 +1,7 @@
 ---
 title: "Perform Teleport Rite"
 lists:
-    - casino
+    - casino-guild
 tier: 5
 osp_cost: 50
 prerequisites: [perform-transport-rite]

--- a/content/skill/perform-transport-rite.md
+++ b/content/skill/perform-transport-rite.md
@@ -1,7 +1,7 @@
 ---
 title: "Perform Transport Rite"
 lists:
-    - casino
+    - casino-guild
     - mages
 tier: 1
 osp_cost: 10

--- a/content/skill/perform-transport-rite.md
+++ b/content/skill/perform-transport-rite.md
@@ -2,7 +2,7 @@
 title: "Perform Transport Rite"
 lists:
     - casino-guild
-    - mages
+    - mages-guild
 tier: 1
 osp_cost: 10
 prerequisites: []

--- a/content/skill/polyglot.md
+++ b/content/skill/polyglot.md
@@ -1,7 +1,7 @@
 ---
 title: "Polyglot"
 lists:
-    - bards
+    - bards-guild
 tier: 5
 osp_cost: 70
 prerequisites: ["Any ", "script-master-x"]

--- a/content/skill/rally.md
+++ b/content/skill/rally.md
@@ -2,7 +2,7 @@
 title: "Rally"
 lists:
     - bards-guild
-    - casino
+    - casino-guild
     - militia
 tier: 4
 osp_cost: 40

--- a/content/skill/rally.md
+++ b/content/skill/rally.md
@@ -3,7 +3,7 @@ title: "Rally"
 lists:
     - bards-guild
     - casino-guild
-    - militia
+    - militia-guild
 tier: 4
 osp_cost: 40
 prerequisites: ["immune-to-mute", " & ", "immune-to-fear"]

--- a/content/skill/rally.md
+++ b/content/skill/rally.md
@@ -1,7 +1,7 @@
 ---
 title: "Rally"
 lists:
-    - bards
+    - bards-guild
     - casino
     - militia
 tier: 4

--- a/content/skill/repair-destroyed-items.md
+++ b/content/skill/repair-destroyed-items.md
@@ -1,7 +1,7 @@
 ---
 title: "Repair Destroyed Items"
 lists:
-    - armourers
+    - armourers-guild
 tier: 2
 osp_cost: 20
 prerequisites: ["weaponsmith-apprentice"]

--- a/content/skill/repair-enchanted-items.md
+++ b/content/skill/repair-enchanted-items.md
@@ -1,7 +1,7 @@
 ---
 title: "Repair Enchanted Items"
 lists:
-    - armourers
+    - armourers-guild
 tier: 2
 osp_cost: 20
 prerequisites: ["armoursmith-apprentice"]

--- a/content/skill/repair-unliving-advanced.md
+++ b/content/skill/repair-unliving-advanced.md
@@ -1,7 +1,7 @@
 ---
 title: "Repair Unliving (Advanced)"
 lists:
-    - corruptors
+    - corruptors-guild
 tier: 2
 osp_cost: 20
 prerequisites: ["revitalise-unliving"]

--- a/content/skill/revitalise-unliving.md
+++ b/content/skill/revitalise-unliving.md
@@ -1,7 +1,7 @@
 ---
 title: "Revitalise Unliving"
 lists:
-    - corruptors
+    - corruptors-guild
 tier: 1
 osp_cost: 10
 prerequisites: []

--- a/content/skill/revive.md
+++ b/content/skill/revive.md
@@ -1,7 +1,7 @@
 ---
 title: "Revive"
 lists:
-    - healers
+    - healers-guild
 tier: 1
 osp_cost: 10
 prerequisites: []

--- a/content/skill/rite-master.md
+++ b/content/skill/rite-master.md
@@ -1,7 +1,7 @@
 ---
 title: "Rite Master"
 lists:
-    - mages
+    - mages-guild
 tier: 1
 osp_cost: 10
 prerequisites: []

--- a/content/skill/ritual-magic-improved.md
+++ b/content/skill/ritual-magic-improved.md
@@ -1,7 +1,7 @@
 ---
 title: "Ritual Magic (Improved)"
 lists:
-    - mages
+    - mages-guild
 tier: 3
 osp_cost: 30
 prerequisites: ["rite-master"]

--- a/content/skill/ritualist-expert.md
+++ b/content/skill/ritualist-expert.md
@@ -1,7 +1,7 @@
 ---
 title: "Ritualist (Expert)"
 lists:
-    - mages
+    - mages-guild
 tier: 4
 osp_cost: 40
 prerequisites: ["ritual-magic-improved"]

--- a/content/skill/ritualist-master.md
+++ b/content/skill/ritualist-master.md
@@ -1,7 +1,7 @@
 ---
 title: "Ritualist (Master)"
 lists:
-    - mages
+    - mages-guild
 tier: 5
 osp_cost: 50
 prerequisites: ["ritualist-expert"]

--- a/content/skill/script-master-x.md
+++ b/content/skill/script-master-x.md
@@ -1,7 +1,7 @@
 ---
 title: "Script Master <X>"
 lists:
-    - bards
+    - bards-guild
 tier: 3
 osp_cost: 30
 prerequisites: ["Any ", "translate-named-script-x", " from the same family"]

--- a/content/skill/shield-mastery-expert.md
+++ b/content/skill/shield-mastery-expert.md
@@ -1,7 +1,7 @@
 ---
 title: "Shield Mastery (Expert)"
 lists:
-    - armourers
+    - armourers-guild
     - militia
 tier: 4
 osp_cost: 40

--- a/content/skill/shield-mastery-expert.md
+++ b/content/skill/shield-mastery-expert.md
@@ -2,7 +2,7 @@
 title: "Shield Mastery (Expert)"
 lists:
     - armourers-guild
-    - militia
+    - militia-guild
 tier: 4
 osp_cost: 40
 prerequisites: ["shield-mastery"]

--- a/content/skill/shield-mastery.md
+++ b/content/skill/shield-mastery.md
@@ -1,7 +1,7 @@
 ---
 title: "Shield Mastery"
 lists:
-    - armourers
+    - armourers-guild
     - militia
 tier: 3
 osp_cost: 30

--- a/content/skill/shield-mastery.md
+++ b/content/skill/shield-mastery.md
@@ -2,7 +2,7 @@
 title: "Shield Mastery"
 lists:
     - armourers-guild
-    - militia
+    - militia-guild
 tier: 3
 osp_cost: 30
 prerequisites: []

--- a/content/skill/sleepless-chanting.md
+++ b/content/skill/sleepless-chanting.md
@@ -1,7 +1,7 @@
 ---
 title: "Sleepless Chanting"
 lists:
-    - bards
+    - bards-guild
 tier: 2
 osp_cost: 20
 prerequisites: []

--- a/content/skill/source-of-life.md
+++ b/content/skill/source-of-life.md
@@ -1,7 +1,7 @@
 ---
 title: "Source of Life"
 lists:
-    - healers
+    - healers-guild
 tier: 5
 osp_cost: 50
 prerequisites: ["mind-healing", " & ", "advanced-healing"]

--- a/content/skill/source-of-unlife.md
+++ b/content/skill/source-of-unlife.md
@@ -1,7 +1,7 @@
 ---
 title: "Source of Unlife"
 lists:
-    - corruptors
+    - corruptors-guild
 tier: 5
 osp_cost: 50
 prerequisites: ["mind-healing", " & ", "repair-unliving-advanced"]

--- a/content/skill/spell-tempering.md
+++ b/content/skill/spell-tempering.md
@@ -1,7 +1,7 @@
 ---
 title: "Spell Tempering"
 lists:
-    - armourers
+    - armourers-guild
 tier: 3
 osp_cost: 30
 prerequisites: ["additional-reforging"]

--- a/content/skill/strikedown-shot.md
+++ b/content/skill/strikedown-shot.md
@@ -1,7 +1,7 @@
 ---
 title: "Strikedown Shot"
 lists:
-    - rangers
+    - rangers-guild
 tier: 4
 osp_cost: 40
 prerequisites: ["immune-to-fumble-and-shatter"]

--- a/content/skill/surgeon.md
+++ b/content/skill/surgeon.md
@@ -1,7 +1,7 @@
 ---
 title: "Surgeon"
 lists:
-    - healers
+    - healers-guild
 tier: 2
 osp_cost: 20
 prerequisites: []

--- a/content/skill/through.md
+++ b/content/skill/through.md
@@ -1,7 +1,7 @@
 ---
 title: "Through"
 lists:
-    - scouts
+    - scouts-guild
 tier: 4
 osp_cost: 40
 prerequisites: ["focused-through"]

--- a/content/skill/tns-spiral.md
+++ b/content/skill/tns-spiral.md
@@ -1,7 +1,7 @@
 ---
 title: "TNS Spiral"
 lists:
-    - scouts
+    - scouts-guild
 tier: 1
 osp_cost: 10
 prerequisites: ["x-oathsworn ", " <Scouts Guild>"]

--- a/content/skill/tracking.md
+++ b/content/skill/tracking.md
@@ -3,7 +3,7 @@ title: "Tracking"
 lists:
     - militia-guild
     - rangers-guild
-    - scouts
+    - scouts-guild
 tier: 1
 osp_cost: 10
 prerequisites: []

--- a/content/skill/tracking.md
+++ b/content/skill/tracking.md
@@ -1,7 +1,7 @@
 ---
 title: "Tracking"
 lists:
-    - militia
+    - militia-guild
     - rangers
     - scouts
 tier: 1

--- a/content/skill/tracking.md
+++ b/content/skill/tracking.md
@@ -2,7 +2,7 @@
 title: "Tracking"
 lists:
     - militia-guild
-    - rangers
+    - rangers-guild
     - scouts
 tier: 1
 osp_cost: 10

--- a/content/skill/transcend-armour.md
+++ b/content/skill/transcend-armour.md
@@ -2,7 +2,7 @@
 title: "Transcend Armour"
 lists:
     - incantors-guild
-    - mages
+    - mages-guild
 tier: 2
 osp_cost: 20
 prerequisites: []

--- a/content/skill/transcend-armour.md
+++ b/content/skill/transcend-armour.md
@@ -1,7 +1,7 @@
 ---
 title: "Transcend Armour"
 lists:
-    - incantors
+    - incantors-guild
     - mages
 tier: 2
 osp_cost: 20

--- a/content/skill/translate-named-script-x.md
+++ b/content/skill/translate-named-script-x.md
@@ -1,7 +1,7 @@
 ---
 title: "Translate Named Script <X>"
 lists:
-    - bards
+    - bards-guild
     - scouts
 tier: 1
 osp_cost: 10

--- a/content/skill/translate-named-script-x.md
+++ b/content/skill/translate-named-script-x.md
@@ -2,7 +2,7 @@
 title: "Translate Named Script <X>"
 lists:
     - bards-guild
-    - scouts
+    - scouts-guild
 tier: 1
 osp_cost: 10
 prerequisites: []

--- a/content/skill/trap-lore.md
+++ b/content/skill/trap-lore.md
@@ -1,7 +1,7 @@
 ---
 title: "Trap Lore"
 lists:
-    - rangers
+    - rangers-guild
     - scouts
 tier: 3
 osp_cost: 30

--- a/content/skill/trap-lore.md
+++ b/content/skill/trap-lore.md
@@ -2,7 +2,7 @@
 title: "Trap Lore"
 lists:
     - rangers-guild
-    - scouts
+    - scouts-guild
 tier: 3
 osp_cost: 30
 prerequisites: []

--- a/content/skill/traverse-faction-wards.md
+++ b/content/skill/traverse-faction-wards.md
@@ -1,7 +1,7 @@
 ---
 title: "Traverse Faction Wards"
 lists:
-    - scouts
+    - scouts-guild
 tier: 3
 osp_cost: 30
 prerequisites: []

--- a/content/skill/unending-voice.md
+++ b/content/skill/unending-voice.md
@@ -1,7 +1,7 @@
 ---
 title: "Unending Voice"
 lists:
-    - bards
+    - bards-guild
 tier: 3
 osp_cost: 30
 prerequisites: ["sleepless-chanting"]

--- a/content/skill/weapon-finesse.md
+++ b/content/skill/weapon-finesse.md
@@ -3,7 +3,7 @@ title: "Weapon Finesse"
 aliases:
     - /skill/through-thrown/
 lists:
-    - scouts
+    - scouts-guild
 tier: 5
 osp_cost: 50
 prerequisites: ["through"]

--- a/content/skill/weaponsmith-apprentice.md
+++ b/content/skill/weaponsmith-apprentice.md
@@ -1,7 +1,7 @@
 ---
 title: "Weaponsmith (Apprentice)"
 lists:
-    - armourers
+    - armourers-guild
 tier: 1
 osp_cost: 10
 prerequisites: []

--- a/content/skill/weaponsmith-artisan.md
+++ b/content/skill/weaponsmith-artisan.md
@@ -1,7 +1,7 @@
 ---
 title: "Weaponsmith (Artisan)"
 lists:
-    - armourers
+    - armourers-guild
 tier: 4
 osp_cost: 40
 prerequisites: ["repair-destroyed-items"]

--- a/content/skill/weaponsmith-master.md
+++ b/content/skill/weaponsmith-master.md
@@ -1,7 +1,7 @@
 ---
 title: "Weaponsmith (Master)"
 lists:
-    - armourers
+    - armourers-guild
 tier: 5
 osp_cost: 50
 prerequisites: ["weaponsmith-artisan"]

--- a/content/skill/written-forgery.md
+++ b/content/skill/written-forgery.md
@@ -2,7 +2,7 @@
 title: "Written Forgery"
 lists:
     - bards-guild
-    - scouts
+    - scouts-guild
 tier: 4
 osp_cost: 40
 prerequisites: ["translate-named-script-x", " & ", "Recognise Forgery"]

--- a/content/skill/written-forgery.md
+++ b/content/skill/written-forgery.md
@@ -1,7 +1,7 @@
 ---
 title: "Written Forgery"
 lists:
-    - bards
+    - bards-guild
     - scouts
 tier: 4
 osp_cost: 40

--- a/themes/lt-osp/layouts/partials/lists/link.html
+++ b/themes/lt-osp/layouts/partials/lists/link.html
@@ -1,1 +1,1 @@
-<a href="{{ .Permalink }}">{{ .Title }}</a>
+<a href="{{ .Permalink }}">{{ .LinkTitle }}</a>

--- a/themes/lt-osp/layouts/partials/lists/nav.html
+++ b/themes/lt-osp/layouts/partials/lists/nav.html
@@ -2,7 +2,7 @@
 {{- partial "lists/nav/parent" (dict "menu" site.Menus.lists "parent" .Parent) -}}
 {{- if .HasChildren }}
 <p>
-    <strong>lists:</strong>
+    <strong>Lists:</strong>
     {{- $len := len .Children }}
     {{- range $index, $e := .Children }}
     {{- if $index }}


### PR DESCRIPTION
Fixes #112. Add `Ω` to the titles of Guild lists, but leave it off the links.